### PR TITLE
feat: add Button, Input and Navbar components

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext.jsx'
+import Navbar from './components/Navbar.jsx'
 
 // ── ProtectedRoute ────────────────────────────────────────────
 // Wraps any route that requires login.
@@ -79,27 +80,32 @@ function Placeholder({ title }) {
 // hooks only work inside the Provider tree.
 function AppRoutes() {
   return (
-    <Routes>
-      {/* Public routes — anyone can access */}
-      <Route path="/"               element={<Placeholder title="Schedule" />} />
-      <Route path="/login"          element={<Placeholder title="Login" />} />
-      <Route path="/register"       element={<Placeholder title="Register" />} />
-      <Route path="/activities"     element={<Placeholder title="Activities" />} />
-      <Route path="/activities/:id" element={<Placeholder title="Activity Detail" />} />
+    <>
+      <Navbar />
+      <main>
+        <Routes>
+          {/* Public routes — anyone can access */}
+          <Route path="/"               element={<Placeholder title="Schedule" />} />
+          <Route path="/login"          element={<Placeholder title="Login" />} />
+          <Route path="/register"       element={<Placeholder title="Register" />} />
+          <Route path="/activities"     element={<Placeholder title="Activities" />} />
+          <Route path="/activities/:id" element={<Placeholder title="Activity Detail" />} />
 
-      {/* Protected route — must be logged in */}
-      <Route
-        path="/profile"
-        element={
-          <ProtectedRoute>
-            <Placeholder title="Profile" />
-          </ProtectedRoute>
-        }
-      />
+          {/* Protected route — must be logged in */}
+          <Route
+            path="/profile"
+            element={
+              <ProtectedRoute>
+                <Placeholder title="Profile" />
+              </ProtectedRoute>
+            }
+          />
 
-      {/* Catch-all: any unknown URL redirects to home */}
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+          {/* Catch-all: any unknown URL redirects to home */}
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </>
   )
 }
 

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -120,19 +120,9 @@ export default function Navbar() {
           ) : (
             // ── Logged out state ──
             <>
-              <NavLink to="/login" style={navLinkStyle}>
-                Log in
-              </NavLink>
-
-              <Button
-                as={Link}
-                to="/register"
-                size="sm"
-              >
-                Join now
-              </Button>
-              {/* as={Link} renders a react-router Link with Button styling.
-                  The 'to' prop is forwarded via ...rest in Button.jsx */}
+                <Button as={Link} to="/login" size="sm">
+                    Log in
+                </Button>
             </>
           )}
         </div>
@@ -183,21 +173,9 @@ export default function Navbar() {
             </>
           ) : (
             <>
-              <NavLink to="/login" onClick={closeMenu} style={S.drawerLink}>
-                Log in
-              </NavLink>
-
-              <NavLink
-                to="/register"
-                onClick={closeMenu}
-                style={{
-                  ...S.drawerLink,
-                  color:      'var(--color-primary-dark)',
-                  fontWeight: 700,
-                }}
-              >
-                Join now
-              </NavLink>
+                <NavLink to="/login" onClick={closeMenu} style={S.drawerLink}>
+                    Log in
+                </NavLink>
             </>
           )}
 

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,0 +1,348 @@
+// Sticky top navigation bar. Present on every page.
+// Auth-aware: changes its right-side links based on login state.
+// Responsive: desktop links collapse into a hamburger on mobile.
+//
+// Reads from AuthContext via useAuth() — no props needed.
+// Uses Button from ui/Button.jsx for consistent button styling.
+
+import React, { useState } from 'react'
+import { Link, NavLink, useNavigate } from 'react-router-dom'
+// Link:     renders an <a> that navigates without page reload
+// NavLink:  same as Link but accepts a style/className function
+//           that receives { isActive: boolean } — used for
+//           the green underline on the current page's link
+// useNavigate: returns a function to programmatically navigate
+//              (used after logout to send user to home)
+
+import { useAuth } from '../context/AuthContext.jsx'
+import Button from './ui/Button.jsx'
+
+export default function Navbar() {
+  const { user, isAuthenticated, logout } = useAuth()
+  // user:            the logged-in user object (or null)
+  // isAuthenticated: boolean — true when user !== null
+  // logout:          clears state + localStorage
+
+  const navigate    = useNavigate()
+  const [menuOpen, setMenuOpen] = useState(false)
+  // menuOpen: controls whether the mobile drawer is visible
+
+  // ── Handlers ─────────────────────────────────────────────────
+  function closeMenu() {
+    setMenuOpen(false)
+  }
+
+  function handleLogout() {
+    logout()
+    // Clears auth state and localStorage token
+    navigate('/')
+    // Send user back to home after logout
+    closeMenu()
+  }
+
+  // ── NavLink style function ────────────────────────────────────
+  // NavLink calls this with { isActive: true/false } automatically.
+  // We return different styles for the active page vs others.
+  // The green underline tells the user which page they're on.
+  function navLinkStyle({ isActive }) {
+    return {
+      fontSize:       'var(--text-base)',
+      fontWeight:     isActive ? 700 : 600,
+      color:          isActive
+                        ? 'var(--color-primary-dark)'
+                        : 'var(--color-text)',
+      borderBottom:   isActive
+                        ? '2px solid var(--color-primary)'
+                        : '2px solid transparent',
+      // Transparent border when inactive keeps layout stable —
+      // without it the element would shift 2px when becoming active
+      paddingBottom:  '2px',
+      textDecoration: 'none',
+      transition:     'color 0.15s',
+      whiteSpace:     'nowrap',
+    }
+  }
+
+  return (
+    <nav style={S.nav}>
+      <div className="container" style={S.inner}>
+
+        {/* ── Brand / Logo ──────────────────────────────────── */}
+        <Link to="/" onClick={closeMenu} style={S.brand}>
+          {/* Clicking the brand always goes to home and closes
+              the mobile menu if it's open */}
+
+          {/* Green square logo box */}
+          <div style={S.logoBox}>
+            <span style={S.logoLetters}>HK</span>
+          </div>
+
+          {/* Text next to the logo */}
+          <div>
+            <span style={S.brandName}>HKIF</span>
+            <span style={S.brandSub}>Högskolan Kristianstad IF</span>
+          </div>
+        </Link>
+
+        {/* ── Desktop links — hidden on mobile via .hide-mobile ── */}
+        <div className="hide-mobile" style={S.desktopLinks}>
+
+          {/* Schedule = home page */}
+          <NavLink to="/" style={navLinkStyle} end>
+            {/* end: only marks as active on exact "/" path.
+                Without end, it would also be active on "/activities" etc. */}
+            Schedule
+          </NavLink>
+
+          <NavLink to="/activities" style={navLinkStyle}>
+            Activities
+          </NavLink>
+
+          {/* Auth-dependent section */}
+          {isAuthenticated ? (
+            // ── Logged in state ──
+            <>
+              <NavLink to="/profile" style={navLinkStyle}>
+                {user?.name || 'Profile'}
+                {/* user.name comes from the backend auth response.
+                    The ?. operator safely reads name even if user is null.
+                    Fallback to 'Profile' if name isn't set. */}
+              </NavLink>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleLogout}
+              >
+                Log out
+              </Button>
+            </>
+          ) : (
+            // ── Logged out state ──
+            <>
+              <NavLink to="/login" style={navLinkStyle}>
+                Log in
+              </NavLink>
+
+              <Button
+                as={Link}
+                to="/register"
+                size="sm"
+              >
+                Join now
+              </Button>
+              {/* as={Link} renders a react-router Link with Button styling.
+                  The 'to' prop is forwarded via ...rest in Button.jsx */}
+            </>
+          )}
+        </div>
+
+        {/* ── Hamburger button — only shown on mobile ─────────── */}
+        {/* .show-mobile class is defined in index.css:
+            display: none on desktop, display: flex on mobile */}
+        <button
+          className="show-mobile"
+          onClick={() => setMenuOpen(prev => !prev)}
+          // Arrow function toggles: false→true, true→false
+          aria-label="Toggle navigation menu"
+          aria-expanded={menuOpen}
+          // aria-expanded tells screen readers if the menu is open
+          style={S.hamburger}
+        >
+          {/* Three bars make the classic hamburger icon */}
+          <span style={S.bar} />
+          <span style={{ ...S.bar, opacity: menuOpen ? 0 : 1 }} />
+          {/* Middle bar fades out when open — visual hint the X is implied */}
+          <span style={S.bar} />
+        </button>
+
+      </div>
+
+      {/* ── Mobile drawer ─────────────────────────────────────── */}
+      {/* Only rendered when menuOpen is true — short-circuit rendering */}
+      {menuOpen && (
+        <div style={S.drawer} role="navigation" aria-label="Mobile menu">
+
+          <NavLink to="/" onClick={closeMenu} style={S.drawerLink} end>
+            Schedule
+          </NavLink>
+
+          <NavLink to="/activities" onClick={closeMenu} style={S.drawerLink}>
+            Activities
+          </NavLink>
+
+          {isAuthenticated ? (
+            <>
+              <NavLink to="/profile" onClick={closeMenu} style={S.drawerLink}>
+                {user?.name || 'Profile'}
+              </NavLink>
+
+              <button onClick={handleLogout} style={S.drawerLogoutBtn}>
+                Log out
+              </button>
+            </>
+          ) : (
+            <>
+              <NavLink to="/login" onClick={closeMenu} style={S.drawerLink}>
+                Log in
+              </NavLink>
+
+              <NavLink
+                to="/register"
+                onClick={closeMenu}
+                style={{
+                  ...S.drawerLink,
+                  color:      'var(--color-primary-dark)',
+                  fontWeight: 700,
+                }}
+              >
+                Join now
+              </NavLink>
+            </>
+          )}
+
+        </div>
+      )}
+    </nav>
+  )
+}
+
+// ── Styles ────────────────────────────────────────────────────
+// Kept at the bottom to not clutter the component logic above.
+const S = {
+  nav: {
+    position:     'sticky',
+    // sticky: the navbar stays at the top of the viewport
+    // as the user scrolls down
+    top:          0,
+    zIndex:       100,
+    // zIndex: ensures the navbar renders above page content
+    // (cards, modals etc. should use lower z-index values)
+    background:   '#ffffff',
+    borderBottom: '1px solid var(--color-border)',
+    height:       'var(--nav-height)',
+    // var(--nav-height) is defined in index.css: 64px
+    boxShadow:    'var(--shadow-sm)',
+  },
+
+  inner: {
+    display:        'flex',
+    alignItems:     'center',
+    justifyContent: 'space-between',
+    height:         '100%',
+    // height: 100% fills the nav bar vertically
+  },
+
+  brand: {
+    display:        'flex',
+    alignItems:     'center',
+    gap:            'var(--space-2)',
+    textDecoration: 'none',
+    flexShrink:     0,
+    // flexShrink: 0 prevents the brand from compressing
+    // when the nav links take up a lot of space
+  },
+
+  logoBox: {
+    width:          36,
+    height:         36,
+    borderRadius:   'var(--radius-sm)',
+    background:     'var(--color-primary)',
+    display:        'flex',
+    alignItems:     'center',
+    justifyContent: 'center',
+    flexShrink:     0,
+  },
+
+  logoLetters: {
+    color:      '#ffffff',
+    fontFamily: 'var(--font-serif)',
+    fontWeight: 700,
+    fontSize:   '13px',
+    lineHeight: 1,
+  },
+
+  brandName: {
+    display:    'block',
+    // display: block makes the <span> stack vertically
+    // instead of sitting inline with brandSub
+    fontFamily: 'var(--font-serif)',
+    fontWeight: 700,
+    fontSize:   'var(--text-lg)',
+    color:      'var(--color-text)',
+    lineHeight: 1.1,
+  },
+
+  brandSub: {
+    display:    'block',
+    fontSize:   'var(--text-xs)',
+    color:      'var(--color-text-muted)',
+    lineHeight: 1.2,
+  },
+
+  desktopLinks: {
+    display:    'flex',
+    alignItems: 'center',
+    gap:        'var(--space-6)',
+  },
+
+  hamburger: {
+    // Bare button reset — all visual treatment is in the bars
+    display:       'flex',
+    flexDirection: 'column',
+    gap:           '5px',
+    background:    'none',
+    border:        'none',
+    padding:       '6px',
+    cursor:        'pointer',
+  },
+
+  bar: {
+    display:      'block',
+    width:        '22px',
+    height:       '2px',
+    background:   'var(--color-text)',
+    borderRadius: '2px',
+    transition:   'opacity 0.2s',
+  },
+
+  drawer: {
+    position:      'absolute',
+    // absolute relative to <nav> which has position: sticky
+    top:           'var(--nav-height)',
+    // Starts immediately below the navbar
+    left:          0,
+    right:         0,
+    background:    '#ffffff',
+    borderBottom:  '1px solid var(--color-border)',
+    boxShadow:     'var(--shadow-md)',
+    display:       'flex',
+    flexDirection: 'column',
+    padding:       'var(--space-4) var(--space-6) var(--space-6)',
+    gap:           'var(--space-4)',
+    zIndex:        99,
+    // One below the nav's zIndex:100 — sits underneath it correctly
+  },
+
+  drawerLink: {
+    fontSize:       'var(--text-base)',
+    fontWeight:     600,
+    color:          'var(--color-text)',
+    textDecoration: 'none',
+    padding:        '4px 0',
+  },
+
+  drawerLogoutBtn: {
+    background:   'none',
+    border:       '1.5px solid var(--color-border)',
+    borderRadius: 'var(--radius-sm)',
+    padding:      '10px var(--space-4)',
+    fontWeight:   600,
+    color:        'var(--color-text-muted)',
+    cursor:       'pointer',
+    textAlign:    'left',
+    fontSize:     'var(--text-base)',
+    fontFamily:   'var(--font-body)',
+    // Must set — buttons don't inherit font
+  },
+}

--- a/client/src/components/ui/Button.jsx
+++ b/client/src/components/ui/Button.jsx
@@ -1,0 +1,220 @@
+// Single button component to be used across the entire app.
+//
+// Props:
+//   variant   — 'primary' | 'outline' | 'ghost' | 'danger'
+//   size      — 'sm' | 'md' | 'lg'
+//   loading   — boolean: shows spinner and disables the button
+//   disabled  — boolean: dims and blocks interaction
+//   fullWidth — boolean: stretches to fill its container
+//   as        — lets you render as <a> or react-router <Link>
+//               e.g. <Button as={Link} to="/register">Join</Button>
+//   type      — 'button' | 'submit' | 'reset' (only for <button> tag)
+//   onClick   — click handler
+//   children  — the label text or content inside the button
+
+import React, { useState } from 'react'
+
+// ── Variant definitions ────────────────────────────────────────
+// Each variant has a default style and a hovered style.
+// We swap between them on mouseEnter/mouseLeave because
+// CSS :hover doesn't work reliably with inline styles.
+const VARIANTS = {
+  primary: {
+    // Solid green — used for the main action on any page
+    default: {
+      background:  'var(--color-primary)',
+      color:       '#ffffff',
+      border:      '2px solid var(--color-primary)',
+    },
+    hover: {
+      background:  'var(--color-primary-dark)',
+      color:       '#ffffff',
+      border:      '2px solid var(--color-primary-dark)',
+    },
+  },
+  outline: {
+    // Transparent with green border — secondary action
+    default: {
+      background:  'transparent',
+      color:       'var(--color-primary-dark)',
+      border:      '2px solid var(--color-primary)',
+    },
+    hover: {
+      background:  'var(--color-primary-light)',
+      color:       'var(--color-primary-dark)',
+      border:      '2px solid var(--color-primary)',
+    },
+  },
+  ghost: {
+    // Subtle grey border — tertiary/low-emphasis action
+    default: {
+      background:  'transparent',
+      color:       'var(--color-text-muted)',
+      border:      '2px solid var(--color-border)',
+    },
+    hover: {
+      background:  'var(--color-surface)',
+      color:       'var(--color-text)',
+      border:      '2px solid var(--color-border)',
+    },
+  },
+  danger: {
+    // Red — destructive actions like delete or deactivate
+    default: {
+      background:  'var(--color-danger)',
+      color:       '#ffffff',
+      border:      '2px solid var(--color-danger)',
+    },
+    hover: {
+      background:  '#a93226',
+      color:       '#ffffff',
+      border:      '2px solid #a93226',
+    },
+  },
+}
+
+// ── Size definitions ───────────────────────────────────────────
+const SIZES = {
+  sm: {
+    padding:    '5px 12px',
+    fontSize:   'var(--text-sm)',
+    gap:        '4px',
+  },
+  md: {
+    padding:    '9px 20px',
+    fontSize:   'var(--text-base)',
+    gap:        '6px',
+  },
+  lg: {
+    padding:    '12px 28px',
+    fontSize:   'var(--text-lg)',
+    gap:        '8px',
+  },
+}
+
+// ── LoadingSpinner ─────────────────────────────────────────────
+// Tiny inline spinner shown inside the button while loading.
+// Uses currentColor so it always matches the button text colour.
+function LoadingSpinner() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display:      'inline-block',
+        width:        '13px',
+        height:       '13px',
+        border:       '2px solid rgba(255,255,255,0.35)',
+        borderTop:    '2px solid currentColor',
+        borderRadius: '50%',
+        animation:    'spin 0.7s linear infinite',
+        flexShrink:   0,
+      }}
+    />
+  )
+}
+
+// ── Button ────────────────────────────────────────────────────
+export default function Button({
+  children,
+  variant   = 'primary',
+  size      = 'md',
+  loading   = false,
+  disabled  = false,
+  fullWidth = false,
+  as: Tag   = 'button',
+  // 'as' allows: <Button as="a" href="..."> or <Button as={Link} to="...">
+  // We rename it to 'Tag' so we can use it as a JSX element name.
+  // JSX element names must start with a capital letter.
+  onClick,
+  type      = 'button',
+  style:    extraStyle = {},
+  className = '',
+  ...rest
+  // ...rest captures any other props (href, to, aria-label, etc.)
+  // and forwards them to the rendered element
+}) {
+  const [hovered, setHovered] = useState(false)
+
+  // Merge disabled states: the button is non-interactive
+  // if explicitly disabled OR if a loading operation is in progress
+  const isDisabled = disabled || loading
+
+  // Look up the style objects for the chosen variant and size
+  const v = VARIANTS[variant] || VARIANTS.primary
+  const s = SIZES[size]       || SIZES.md
+
+  // Choose between default and hover styles
+  const variantStyle = hovered && !isDisabled ? v.hover : v.default
+
+  const buttonStyle = {
+    // Layout
+    display:        'inline-flex',
+    // inline-flex: sits in text flow like inline, but lets us
+    // use flexbox inside to centre the spinner + label
+    alignItems:     'center',
+    justifyContent: 'center',
+    gap:            s.gap,
+    width:          fullWidth ? '100%' : 'auto',
+
+    // Sizing
+    padding:    s.padding,
+    fontSize:   s.fontSize,
+
+    // Typography
+    fontWeight:     600,
+    fontFamily:     'var(--font-body)',
+    // Must set fontFamily — buttons don't inherit it by default
+    lineHeight:     1.2,
+    textDecoration: 'none',
+    // Prevents underline when Button is rendered as an <a> tag
+    whiteSpace:     'nowrap',
+
+    // Shape
+    borderRadius: 'var(--radius-sm)',
+
+    // Colour — comes from the variant
+    ...variantStyle,
+
+    // State
+    cursor:  isDisabled ? 'not-allowed' : 'pointer',
+    opacity: isDisabled ? 0.5 : 1,
+
+    // Transition — smooths out the hover colour change
+    transition: 'background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s',
+
+    // Allow caller to pass extra overrides
+    ...extraStyle,
+  }
+
+  return (
+    <Tag
+      // Only pass type="submit" etc. when rendering as a <button>
+      // <a> tags don't have a type attribute
+      type={Tag === 'button' ? type : undefined}
+
+      onClick={isDisabled ? undefined : onClick}
+      // Prevent click when disabled — even if the caller passes onClick
+
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+
+      disabled={Tag === 'button' ? isDisabled : undefined}
+      // The disabled HTML attribute only works on <button>, not <a>
+
+      aria-busy={loading}
+      // Tells screen readers the button is processing
+
+      aria-disabled={isDisabled}
+      // Tells screen readers this element is not interactive
+
+      style={buttonStyle}
+      className={className}
+
+      {...rest}
+      // Forward href, to, aria-label, data-* etc.
+    >
+      {loading && <LoadingSpinner />}
+      {children}
+    </Tag>
+  )
+}

--- a/client/src/components/ui/Input.jsx
+++ b/client/src/components/ui/Input.jsx
@@ -1,0 +1,144 @@
+// A labelled form field with built-in error and hint display.
+// Handles its own focus styling so pages don't need any input CSS.
+//
+// Props:
+//   label    — string shown above the field
+//   error    — string shown below in red when validation fails
+//   hint     — string shown below in grey as helper text
+//   id       — ties the label to the input for accessibility
+//              auto-generated from label if not provided
+//   style    — extra styles on the wrapper div
+//   ...rest  — any valid <input> props: type, value, onChange,
+//              placeholder, disabled, autoFocus, autoComplete, etc.
+
+import React, { useState } from 'react'
+
+export default function Input({
+  label,
+  error,
+  hint,
+  id,
+  style: extraStyle = {},
+  ...rest
+  // ...rest captures type, value, onChange, placeholder, disabled,
+  // autoFocus, autoComplete, required, name, min, max, etc.
+  // They all get spread onto the <input> element below.
+}) {
+  const [focused, setFocused] = useState(false)
+  // focused: true when the user has clicked into this field.
+  // We use this to show a green focus ring — CSS :focus doesn't
+  // work reliably when mixing inline styles and class styles.
+
+  // Auto-generate an id from the label text if none is provided.
+  // This ties the <label> to the <input> for screen readers:
+  // clicking the label focuses the input.
+  // e.g. label="Email address" → id="email-address"
+  const inputId = id || (label
+    ? label.toLowerCase().replace(/\s+/g, '-')
+    : undefined)
+
+  // ── Border colour logic ─────────────────────────────────────
+  // Priority: error (red) > focused (green) > default (grey)
+  let borderColor = 'var(--color-border)'
+  if (error)   borderColor = 'var(--color-danger)'
+  if (focused && !error) borderColor = 'var(--color-primary)'
+
+  // ── Focus ring (box-shadow) ─────────────────────────────────
+  // A soft coloured glow behind the border — matches the HKR
+  // design system and helps users with low vision find the cursor.
+  let boxShadow = 'none'
+  if (focused && !error) boxShadow = '0 0 0 3px rgba(90,158,31,0.15)'
+  if (error)             boxShadow = '0 0 0 3px rgba(192,57,43,0.12)'
+
+  return (
+    <div style={{
+      // The wrapper stacks: label → input → error/hint
+      display:       'flex',
+      flexDirection: 'column',
+      gap:           'var(--space-1)',
+      // gap between label and input, and input and helper text
+      width:         '100%',
+      ...extraStyle,
+    }}>
+
+      {/* Label — only rendered if the label prop is provided */}
+      {label && (
+        <label
+          htmlFor={inputId}
+          // htmlFor must match the input's id for accessibility
+          style={{
+            fontSize:   'var(--text-sm)',
+            fontWeight: 600,
+            color:      error ? 'var(--color-danger)' : 'var(--color-text)',
+            // Label turns red when there's a validation error
+            // so the user immediately sees which field has a problem
+            lineHeight: 1.3,
+          }}
+        >
+          {label}
+        </label>
+      )}
+
+      {/* The actual input element */}
+      <input
+        id={inputId}
+
+        onFocus={() => setFocused(true)}
+        // Called when user clicks or tabs into the field
+
+        onBlur={() => setFocused(false)}
+        // Called when user leaves the field
+        // We keep error visible after blur so users see what to fix
+
+        style={{
+          width:        '100%',
+          padding:      '9px 13px',
+          border:       `1.5px solid ${borderColor}`,
+          borderRadius: 'var(--radius-sm)',
+          fontSize:     'var(--text-base)',
+          fontFamily:   'var(--font-body)',
+          // Must set — inputs don't inherit font-family
+          color:        'var(--color-text)',
+          background:   rest.disabled ? 'var(--color-surface)' : '#ffffff',
+          // Dimmed background when disabled so it looks non-interactive
+          outline:      'none',
+          // Remove browser default focus ring — we use box-shadow instead
+          boxShadow,
+          transition:   'border-color 0.15s, box-shadow 0.15s',
+          cursor:       rest.disabled ? 'not-allowed' : 'text',
+          opacity:      rest.disabled ? 0.65 : 1,
+          lineHeight:   1.5,
+        }}
+
+        {...rest}
+        // Spread all other props: type, value, onChange,
+        // placeholder, disabled, autoFocus, autoComplete, etc.
+      />
+
+      {/* Error message — shown when error prop is set */}
+      {error && (
+        <p style={{
+          fontSize:  'var(--text-xs)',
+          color:     'var(--color-danger)',
+          marginTop: '1px',
+          lineHeight: 1.3,
+        }}>
+          {error}
+        </p>
+      )}
+
+      {/* Hint text — shown when hint is set and there's no error */}
+      {hint && !error && (
+        <p style={{
+          fontSize:  'var(--text-xs)',
+          color:     'var(--color-text-muted)',
+          marginTop: '1px',
+          lineHeight: 1.3,
+        }}>
+          {hint}
+        </p>
+      )}
+
+    </div>
+  )
+}

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -16,7 +16,7 @@ import React, {
   useEffect,      // runs side effects (e.g. reading localStorage on mount)
 } from 'react'
 
-import { loginRequest, registerRequest } from '../services/authService.js'
+import { loginRequest, registerRequest } from '../services/AuthService.js'
 
 // ── TOKEN KEY ─────────────────────────────────────────────────
 // Single constant for the localStorage key name.


### PR DESCRIPTION
## What this PR does

Adds the first three shared UI components needed by every page in the app.
All components use the design tokens from `index.css` — no hardcoded colours
or sizes anywhere.

Also fixes a case bug in the AuthService import that would have broken
the build on Linux/Mac.

---

## Bug fix included

`AuthContext.jsx` was importing `authService.js` (lowercase) but the file
on disk is `AuthService.js` (uppercase). This works on Windows but crashes
on Linux and Mac due to case-sensitive file systems.

---

## Files added

| File | Purpose |
|---|---|
| `client/src/components/ui/Button.jsx` | Shared button with 4 variants and 3 sizes |
| `client/src/components/ui/Input.jsx` | Labelled input with error and hint states |
| `client/src/components/Navbar.jsx` | Sticky auth-aware navbar with mobile drawer |

## Files changed

| File | Change |
|---|---|
| `client/src/App.jsx` | Added `<Navbar />` above `<Routes>` |
| `client/src/context/AuthContext.jsx` | Fixed AuthService import casing |

---

## Component → Route map

### Navbar — every route
Rendered once in `AppRoutes`, above `<Routes>`, so it appears on all pages.

| Route | Active link | Right side |
|---|---|---|
| `/` | Schedule underlined | Log in + Join now (logged out) |
| `/login` | none | Log in + Join now |
| `/register` | none | Log in + Join now |
| `/activities` | Activities underlined | Log in + Join now |
| `/activities/:id` | Activities underlined | Log in + Join now |
| `/profile` | Profile underlined | user name + Log out (logged in) |

---

### Button

| Route | Variant | Label |
|---|---|---|
| `/login` | primary | "Sign in" / "Signing in…" with spinner |
| `/register` | primary | "Create account" / loading |
| `/` | primary | "Sign in" hero CTA |
| `/` | ghost | "View schedule ↓" |
| `/activities` | outline | "View details" per card |
| `/activities/:id` | primary | "+ I'm interested" / "✓ Interested" |
| `/profile` | ghost | "Log out" |

---

### Input

| Route | Fields |
|---|---|
| `/login` | Email address (type=email), Password (type=password) |
| `/register` | Full name, Email address, Password, Confirm password |

---

## How to test locally

```bash
git fetch origin
git checkout feat/ui-components-navbar-button-input
cd client
npm install
npm run dev
```

1. Open `localhost:5173` — Navbar should be visible
2. Navigate between routes — active link underlines update
3. Paste this in DevTools console to test logged-in state:
```js
localStorage.setItem('hkif_token', 'test')
localStorage.setItem('hkif_user', JSON.stringify({id:1,email:'test@hkr.se',name:'Alex',role:'USER'}))
```
4. Refresh — Navbar should show "Alex" and "Log out"
5. Click Log out — reverts to logged-out state
6. Resize to mobile — hamburger appears, links collapse
