### PR TITLE
feat: add Card, Badge and Modal components with barrel export

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -15,7 +15,7 @@ import { Link, NavLink, useNavigate } from 'react-router-dom'
 //              (used after logout to send user to home)
 
 import { useAuth } from '../context/AuthContext.jsx'
-import Button from './ui/Button.jsx'
+import { Button } from './ui'
 
 export default function Navbar() {
   const { user, isAuthenticated, logout } = useAuth()

--- a/client/src/components/ui/Badge.jsx
+++ b/client/src/components/ui/Badge.jsx
@@ -1,0 +1,112 @@
+// A small coloured pill label.
+// Can be used for status indicators and role tags throughout the app.
+//
+// Props:
+//   variant  — controls the colour scheme
+//   style    — extra inline styles
+//   children — the label text
+//
+// Variants:
+//   success  — green  — active sessions, positive states
+//   danger   — red    — cancelled, errors, destructive
+//   warning  — amber  — delayed, pending, caution
+//   neutral  — grey   — inactive, default role (USER)
+//   info     — blue   — informational, board member role
+
+import React from 'react'
+
+// ── Variant colour map ─────────────────────────────────────────
+// Each variant has a background tint and a darker text colour.
+// The tint is always the light version of the semantic colour
+// from index.css so they stay consistent with the design tokens.
+const VARIANTS = {
+  success: {
+    background: 'var(--color-primary-light)',
+    color:      'var(--color-primary-dark)',
+  },
+  danger: {
+    background: 'var(--color-danger-light)',
+    color:      'var(--color-danger)',
+  },
+  warning: {
+    background: 'var(--color-warning-light)',
+    color:      'var(--color-warning)',
+  },
+  neutral: {
+    background: '#f0f0ee',
+    color:      '#555555',
+  },
+  info: {
+    background: '#e8f0fc',
+    color:      '#1a5fac',
+  },
+}
+
+// ── STATUS_VARIANT ─────────────────────────────────────────────
+// Tryed to match status strings backend returns
+// to the correct badge variant.
+//
+// can bu used on ActivitiesPage or WeeklyCalendar:
+//   import Badge, { STATUS_VARIANT } from '../components/ui/Badge.jsx'
+//   <Badge variant={STATUS_VARIANT[activity.status]}>
+//     {activity.status}
+//   </Badge>
+//
+// The values match the backend's ActivityStatus enum in schema.prisma
+export const STATUS_VARIANT = {
+  ACTIVE:    'success',
+  INACTIVE:  'neutral',
+  CANCELLED: 'danger',
+  DELAYED:   'warning',
+}
+
+// ── ROLE_VARIANT ───────────────────────────────────────────────
+// Maps the backend's ProfileRole enum values to badge variants.
+//
+// Usage in ProfilePage:
+//   import Badge, { ROLE_VARIANT } from '../components/ui/Badge.jsx'
+//   <Badge variant={ROLE_VARIANT[user.role]}>{user.role}</Badge>
+export const ROLE_VARIANT = {
+  USER:         'neutral',
+  LEADER:       'success',
+  BOARD_MEMBER: 'info',
+  ADMIN:        'warning',
+}
+
+// ── Badge component ────────────────────────────────────────────
+export default function Badge({
+  children,
+  variant = 'success',
+  style:  extraStyle = {},
+}) {
+  const v = VARIANTS[variant] || VARIANTS.neutral
+  // Fall back to neutral if an unknown variant is passed
+
+  return (
+    <span style={{
+      display:       'inline-block',
+      // inline-block: sits in text flow but respects
+      // padding and border-radius
+      padding:       '2px 10px',
+      borderRadius:  'var(--radius-xl)',
+      // radius-xl = 20px — creates the pill shape
+
+      fontSize:      'var(--text-xs)',
+      fontWeight:    700,
+      textTransform: 'uppercase',
+      letterSpacing: '0.04em',
+      // Uppercase + letter-spacing makes short labels
+      // like "USER" more readable at small sizes
+
+      whiteSpace:    'nowrap',
+      // Prevent the badge text from wrapping to a second line
+
+      background:    v.background,
+      color:         v.color,
+
+      ...extraStyle,
+    }}>
+      {children}
+    </span>
+  )
+}

--- a/client/src/components/ui/Card.jsx
+++ b/client/src/components/ui/Card.jsx
@@ -1,0 +1,101 @@
+// A generic white container with rounded corners and a shadow.
+// Used anywhere content needs to be visually grouped.
+//
+// Props:
+//   padding   — 'none' | 'sm' | 'md' | 'lg'
+//   shadow    — 'none' | 'sm' | 'md'
+//   border    — 'default' | 'accent' | 'none'
+//   radius    — 'md' | 'lg'
+//   onClick   — makes the card clickable (adds hover lift effect)
+//   as        — render as a different element, e.g. as="article"
+//   children  — content inside the card
+//   style     — extra inline styles on the card element
+
+import React, { useState } from 'react'
+
+// ── Padding options ────────────────────────────────────────────
+const PADDING = {
+  none: '0',
+  sm:   'var(--space-3) var(--space-4)',
+  md:   'var(--space-6)',
+  lg:   'var(--space-8)',
+}
+
+// ── Shadow options ─────────────────────────────────────────────
+const SHADOW = {
+  none: 'none',
+  sm:   'var(--shadow-sm)',
+  md:   'var(--shadow-md)',
+}
+
+// ── Border options ─────────────────────────────────────────────
+// 'accent' is used when a card needs to stand out —
+// e.g. the selected activity or a featured item.
+const BORDER = {
+  default: '1px solid var(--color-border)',
+  accent:  '2px solid var(--color-primary)',
+  none:    'none',
+}
+
+export default function Card({
+  children,
+  padding   = 'md',
+  shadow    = 'sm',
+  border    = 'default',
+  radius    = 'md',
+  onClick,
+  as: Tag   = 'div',
+  // 'as' lets pages render Card as <article>, <section>, <li> etc.
+  // for correct HTML semantics (activity list → article cards)
+  style:    extraStyle = {},
+  ...rest
+}) {
+  const [hovered, setHovered] = useState(false)
+
+  // A card is clickable if an onClick handler is passed.
+  // Clickable cards get a hover lift effect.
+  const isClickable = typeof onClick === 'function'
+
+  const cardStyle = {
+    background:   'var(--color-surface-raised)',
+    // surface-raised = white. Sits above the page surface (#f5f5f3)
+    borderRadius: radius === 'lg'
+                    ? 'var(--radius-lg)'
+                    : 'var(--radius-md)',
+    border:       BORDER[border] || BORDER.default,
+    padding:      PADDING[padding] || PADDING.md,
+
+    // Shadow gets stronger on hover when clickable —
+    // gives physical feedback that this card is interactive
+    boxShadow: isClickable && hovered
+                 ? 'var(--shadow-md)'
+                 : SHADOW[shadow] || SHADOW.sm,
+
+    cursor:    isClickable ? 'pointer' : 'default',
+
+    // Lift effect: card rises 2px on hover when clickable.
+    // translateY(-2px) moves the element 2px upward.
+    transform:   isClickable && hovered
+                   ? 'translateY(-2px)'
+                   : 'translateY(0)',
+
+    transition: 'box-shadow 0.15s, transform 0.15s',
+    // Smooth animation for the hover effect
+
+    ...extraStyle,
+  }
+
+  return (
+    <Tag
+      onClick={onClick}
+      onMouseEnter={() => isClickable && setHovered(true)}
+      onMouseLeave={() => isClickable && setHovered(false)}
+      // Only track hover state when card is clickable —
+      // no point running state updates on non-interactive cards
+      style={cardStyle}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,0 +1,186 @@
+// A dialog that appears centred over the page with a dark backdrop.
+// Traps focus and closes on Escape key or backdrop click.
+//
+// Props:
+//   open      — boolean: controls whether the modal is visible
+//   onClose   — function: called when user closes the modal
+//   title     — string: shown in the modal header
+//   children  — content rendered inside the modal body
+//   maxWidth  — string: max-width of the modal box (default '440px')
+
+import React, { useEffect, useRef } from 'react'
+
+export default function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  maxWidth = '440px',
+}) {
+
+  // ── Close on Escape key ───────────────────────────────────────
+  // useEffect runs after render. The return function "cleans up"
+  // by removing the event listener when the modal closes or unmounts.
+  useEffect(() => {
+    if (!open) return
+    // If modal is closed there's no listener to add
+
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') onClose()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      // Cleanup: remove the listener when modal closes.
+      // Without this, old listeners would stack up every time
+      // the modal opens and closes.
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onClose])
+  // Re-run this effect when open or onClose changes
+
+  // ── Prevent background scrolling while open ───────────────────
+  // When a modal is open you don't want the page behind it to scroll
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+
+    return () => {
+      // Always restore scrolling when component unmounts
+      document.body.style.overflow = ''
+    }
+  }, [open])
+
+  // ── Focus management ──────────────────────────────────────────
+  // Move focus into the modal when it opens so keyboard users
+  // don't have to tab all the way from the top of the page
+  const modalRef = useRef(null)
+
+  useEffect(() => {
+    if (open && modalRef.current) {
+      modalRef.current.focus()
+    }
+  }, [open])
+
+  // ── Don't render when closed ──────────────────────────────────
+  // Returning null removes the modal from the DOM entirely.
+  // This is better than just hiding it with display:none because
+  // screen readers won't pick it up when it's not rendered.
+  if (!open) return null
+
+  return (
+    <>
+      {/* ── Backdrop ──────────────────────────────────────────── */}
+      {/* Semi-transparent overlay behind the modal.
+          Clicking it closes the modal — common expected behaviour. */}
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        // aria-hidden: backdrop is decorative — screen readers ignore it
+        style={{
+          position:   'fixed',
+          // fixed: stays in place even when page is scrolled
+          inset:      0,
+          // inset: 0 is shorthand for top:0, right:0, bottom:0, left:0
+          // covers the entire viewport
+          background: 'rgba(0, 0, 0, 0.45)',
+          zIndex:     200,
+        }}
+      />
+
+      {/* ── Modal box ─────────────────────────────────────────── */}
+      <div
+        ref={modalRef}
+        role="dialog"
+        // role="dialog": tells screen readers this is a modal dialog
+        aria-modal="true"
+        // aria-modal: tells screen readers to ignore content behind it
+        aria-labelledby="modal-title"
+        // aria-labelledby points to the heading inside the modal
+        tabIndex={-1}
+        // tabIndex=-1: allows the div to receive focus programmatically
+        // (via modalRef.current.focus()) without appearing in tab order
+        style={{
+          position:   'fixed',
+          top:        '50%',
+          left:       '50%',
+          transform:  'translate(-50%, -50%)',
+          // This combination of top/left/transform perfectly centres
+          // the modal regardless of its dimensions
+          zIndex:     201,
+          // One above the backdrop so it renders on top
+          background: '#ffffff',
+          borderRadius: 'var(--radius-lg)',
+          boxShadow:  'var(--shadow-lg)',
+          padding:    'var(--space-8)',
+          width:      '90%',
+          // 90% width on small screens so it doesn't touch the edges
+          maxWidth:   maxWidth,
+          maxHeight:  '90vh',
+          // Limit height so the modal doesn't overflow the viewport
+          overflowY:  'auto',
+          // If content is taller than 90vh, scroll inside the modal
+          outline:    'none',
+          // Remove the default focus outline from the div —
+          // the modal itself is visually obvious enough
+        }}
+      >
+
+        {/* ── Modal header ────────────────────────────────────── */}
+        <div style={{
+          display:        'flex',
+          alignItems:     'flex-start',
+          justifyContent: 'space-between',
+          gap:            'var(--space-4)',
+          borderBottom:   '3px solid var(--color-primary)',
+          paddingBottom:  'var(--space-4)',
+          marginBottom:   'var(--space-6)',
+        }}>
+          <h2
+            id="modal-title"
+            // id matches aria-labelledby above —
+            // screen readers announce this heading when modal opens
+            style={{
+              fontFamily: 'var(--font-serif)',
+              fontWeight: 700,
+              fontSize:   'var(--text-xl)',
+              color:      'var(--color-text)',
+              lineHeight: 1.2,
+            }}
+          >
+            {title}
+          </h2>
+
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            aria-label="Close modal"
+            style={{
+              background:   'none',
+              border:       'none',
+              fontSize:     '1.1rem',
+              color:        'var(--color-text-muted)',
+              cursor:       'pointer',
+              padding:      '2px 6px',
+              borderRadius: 'var(--radius-sm)',
+              lineHeight:   1,
+              flexShrink:   0,
+              // flexShrink:0 — don't let the close button compress
+              // when the title is long
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* ── Modal body — whatever is passed as children ──────── */}
+        {children}
+
+      </div>
+    </>
+  )
+}

--- a/client/src/components/ui/index.jsx
+++ b/client/src/components/ui/index.jsx
@@ -1,0 +1,12 @@
+// Central export point for all shared UI components.
+// Import from this file instead of individual component files.
+//
+// Usage:
+//   import { Button, Input, Card, Badge, Modal } from '../components/ui'
+//   import { Badge, STATUS_VARIANT, ROLE_VARIANT } from '../components/ui'
+
+export { default as Button }                    from './Button.jsx'
+export { default as Input  }                    from './Input.jsx'
+export { default as Card   }                    from './Card.jsx'
+export { default as Badge, STATUS_VARIANT, ROLE_VARIANT } from './Badge.jsx'
+export { default as Modal  }                    from './Modal.jsx'


### PR DESCRIPTION
## What this PR does

Completes the base UI component library started in the previous PR.
Adds Card, Badge and Modal — the three remaining shared components
needed by the activities page, calendar page and profile page.

Also adds `components/ui/index.jsx` so all components can be
imported from a single path.

---

## Files added

| File | Purpose |
|---|---|
| `components/ui/Badge.jsx` | Status and role pill labels |
| `components/ui/Card.jsx` | White content container with shadow and clickable variant |
| `components/ui/Modal.jsx` | Accessible dialog with backdrop and ESC close |
| `components/ui/index.jsx` | Single import point for all ui components |

---

## How to import after merge

```js
// Single import for everything
import { Card, Badge, Modal, Button, Input } from '../components/ui'

// Badge with backend status helpers
import { Badge, STATUS_VARIANT, ROLE_VARIANT } from '../components/ui'

// Map backend values directly to correct colour
<Badge variant={STATUS_VARIANT[activity.status]}>
  {activity.status}
</Badge>

// STATUS_VARIANT maps:
// ACTIVE    → green
// CANCELLED → red
// DELAYED   → amber
// INACTIVE  → grey

// ROLE_VARIANT maps:
// USER         → grey
// LEADER       → green
// BOARD_MEMBER → blue
// ADMIN        → amber
```

---

## Component → Route map

### Badge
| Route | Usage |
|---|---|
| `/activities` | Activity status per card |
| `/activities/:id` | Status next to activity title |
| `/profile` | User role label |
| `/` calendar | Cancelled session indicator |

### Card
| Route | Usage |
|---|---|
| `/login` | Wraps the login form |
| `/register` | Wraps the register form |
| `/activities` | One card per activity in the grid |
| `/activities/:id` | Wraps the full activity detail |
| `/profile` | Stats section and tab content |

### Modal
| Route | Usage |
|---|---|
| `/` | Sign-in prompt when logged-out user clicks interest button |
| `/activities/:id` | Same — interest button without login |

---