### PR TITLE
Updated schedule-GET routes to the current standard

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import { errorHandler } from './middleware/errorHandler';
 // routers
 import authRoutes from './routes/auth.routes';
 import activityRoutes from './routes/activities.routes';
+import scheduleRoutes from "./routes/schedule.routes";
 
 export const app = express();
 
@@ -20,7 +21,7 @@ app.get('/api/health', (_req, res) => {
 // Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/activities', activityRoutes);
-// TODO: app.use('/api/schedules', scheduleRoutes);
+app.use('/api/schedules', scheduleRoutes);
 // TODO: app.use('/api/users', userRoutes);
 
 // 404 catch-all (must be last route)

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -3,7 +3,7 @@ import {ApiError} from "../utils/ApiError";
 import {Request, Response} from "express";
 import {asyncHandler} from "../middleware/asyncHandler";
 import {ApiResponse} from "../types";
-import { ScheduleDto } from '../types/schedule.types';
+import {ScheduleDto} from '../types'
 import {ScheduleDateSchema, ScheduleBoolWeekSchema} from "../validators/schedule.validator";
 import {output, ZodISODate, ZodLiteral, ZodNullable, ZodOptional, ZodUnion} from "zod";
 

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -4,6 +4,8 @@ import {Request, Response} from "express";
 import {asyncHandler} from "../middleware/asyncHandler";
 import {ApiResponse} from "../types";
 import { ScheduleDto } from '../types/schedule.types';
+import {ScheduleDateSchema, ScheduleBoolWeekSchema} from "../validators/schedule.validator";
+import {output, ZodISODate, ZodLiteral, ZodNullable, ZodOptional, ZodUnion} from "zod";
 
 const currentWeek = asyncHandler(
     async (_req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
@@ -18,43 +20,35 @@ const currentWeek = asyncHandler(
  */
 const getSchedule = asyncHandler(
     async (req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
-        if(!req.query){
-            const thisWeek: ScheduleDto[] = await READ.currentSchedule();
-            res.status(200).json({status: "success", data: thisWeek});
+        let schedule: ScheduleDto[];
+        let date: output<ZodOptional<ZodNullable<ZodUnion<readonly [ZodISODate, ZodLiteral<"today">]>>>> | Date;
+        let entireWeek: boolean | null;
+        const resultDate = ScheduleDateSchema.safeParse(req.query.date);
+        const resultBool = ScheduleBoolWeekSchema.safeParse(req.query.entireWeek);
+        if(!resultDate.success) throw ApiError.badRequest(`Invalid Query Values: Bad date ${req.query.date}`);
+        else { date = resultDate.data}
+
+        if(!resultBool.success) throw ApiError.badRequest(`Invalid Query Values: Bad Boolean ${req.query.entireWeek}`);
+        else{ entireWeek = resultBool.data}
+
+
+        if (!date || date === "today") {
+            date = new Date();
+            date = date as Date;
+        } else{
+            date = new Date(date);
+        }
+        date.setUTCHours(0, 0, 0, 0);
+        if( typeof entireWeek === "undefined"){ entireWeek = true}
+        if (entireWeek) {
+            schedule = await READ.anyWeekSchedule(date);
+            res.status(200).json({status: "success", data: schedule});
             return;
         }
         else {
-            let schedule: ScheduleDto[];
-            let date: string | Date | null = req.query.date as (Date | string | null);
-            let entireWeek: string | boolean = req.query.entireWeek as string;
-
-            if (!date || date === "today") {
-                date = new Date();
-            }
-            else {
-                if (typeof date === "string"){ // or better check for "YYYY-MM-dd" format?
-                    date = new Date(date)
-                }
-            }
-            date.setUTCHours(0, 0, 0);
-
-            if (typeof entireWeek === "undefined") {
-                entireWeek = true;
-            }
-            if ( typeof entireWeek === "string"){
-                entireWeek = entireWeek === "true";
-            }
-
-            if (entireWeek) {
-                schedule = await READ.anyWeekSchedule(date);
-                res.status(200).json({status: "success", data: schedule});
-                return;
-            }
-            else {
-                schedule = await READ.anyDaySchedule(date) ?? [];
-                res.status(200).json({status: "success", data: schedule});
-                return;
-            }
+            schedule = await READ.anyDaySchedule(date) ?? [];
+            res.status(200).json({status: "success", data: schedule});
+            return;
         }
     }
 )

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -20,7 +20,7 @@ const currentWeek = asyncHandler(
  */
 const getSchedule = asyncHandler(
     async (req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
-        let schedule: ScheduleDto[];
+        let schedule: ScheduleDto[];// ScheduleDto[]
         let date: output<ZodOptional<ZodNullable<ZodUnion<readonly [ZodISODate, ZodLiteral<"today">]>>>> | Date;
         let entireWeek: boolean | null;
         const resultDate = ScheduleDateSchema.safeParse(req.query.date);

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -2,18 +2,13 @@ import {READ}  from '../db/readQueries'
 import {ApiError} from "../utils/ApiError";
 import {Request, Response} from "express";
 import {asyncHandler} from "../middleware/asyncHandler";
-// import {ActivityTemplateModel, ProfileModel, FavoriteModel} from '../generated/prisma/models'
+import {ApiResponse} from "../types";
+import { ScheduleDto } from '../types/schedule.types';
 
 const currentWeek = asyncHandler(
-    async (_req: Request, res: Response) => {
-        const schedule = await READ.currentSchedule();
-        if(schedule){
-            res.status(200).json(schedule)
-        }
-        else{
-            // res.send(ApiError.notFound("The Week you are requesting hasn't been scheduled yet!"))
-            throw ApiError.notFound("The Week you are requesting hasn't been scheduled yet!")
-        }
+    async (_req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
+        const schedule: ScheduleDto[] = await READ.currentSchedule();
+        res.status(200).json({status: "success", data: schedule})
     }
 )
 
@@ -22,58 +17,43 @@ const currentWeek = asyncHandler(
  * route: '/api/schedules?date=<someDate>&entireWeek=<boolean>'
  */
 const getSchedule = asyncHandler(
-    async (req: Request, res: Response) => {
+    async (req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
         if(!req.query){
-            const thisWeek = await READ.currentSchedule();
-            if(thisWeek){
-                res.status(200).json(thisWeek);
-            } else{
-                throw ApiError.notFound("The Week you are requesting hasn't been scheduled yet!")
-            }
+            const thisWeek: ScheduleDto[] = await READ.currentSchedule();
+            res.status(200).json({status: "success", data: thisWeek});
             return;
         }
         else {
-            let schedule;
-            let date: Date | string | null = req.query.date as (Date | string | null);
+            let schedule: ScheduleDto[];
+            let date: string | Date | null = req.query.date as (Date | string | null);
             let entireWeek: string | boolean = req.query.entireWeek as string;
 
             if (!date || date === "today") {
-                date = new Date(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate());
+                date = new Date();
             }
             else {
                 if (typeof date === "string"){ // or better check for "YYYY-MM-dd" format?
                     date = new Date(date)
                 }
             }
+            date.setUTCHours(0, 0, 0);
 
             if (typeof entireWeek === "undefined") {
                 entireWeek = true;
             }
             if ( typeof entireWeek === "string"){
-                if( entireWeek ===  "true"){
-                    entireWeek = true;
-                } else{
-                    entireWeek = false
-                }
+                entireWeek = entireWeek === "true";
             }
 
             if (entireWeek) {
                 schedule = await READ.anyWeekSchedule(date);
-                if (!schedule || schedule.length === 0) {
-                    throw ApiError.notFound("The Week you are requesting hasn't been scheduled yet! Or has been deleted!")
-                } else {
-                    res.status(200).json(schedule);
-                    return;
-                }
+                res.status(200).json({status: "success", data: schedule});
+                return;
             }
             else {
-                schedule = await READ.anyDaySchedule(date);
-                if (!schedule|| schedule.length === 0) {
-                    throw ApiError.notFound("The Day you are requesting hasn't been scheduled yet! Or has been deleted!")
-                } else {
-                    res.status(200).json(schedule);
-                    return;
-                }
+                schedule = await READ.anyDaySchedule(date) ?? [];
+                res.status(200).json({status: "success", data: schedule});
+                return;
             }
         }
     }

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -1,8 +1,7 @@
 import { prisma } from "./prisma";
 import { startAndEndOfWeek } from "../utils/weekCalculator";
 import { ActivityTemplate } from "../generated/prisma";
-import {ScheduleDto} from "../types/schedule.types";
-
+import { ScheduleDto } from '../types'
 export class READ {
     /**
      * Purpose: returns the current schedule of the week

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -21,11 +21,11 @@ export class READ {
      *      **SUCCESS** --> array filled with ScheduleDto objects
      *      **FAIL** --> empty array
      */
-    static async anyWeekSchedule(date: Date): Promise<ScheduleDto[]> {//
+    static async anyWeekSchedule(date: Date): Promise<ScheduleDto[]> {//: Promise<ScheduleDto[]>
         const { startDay, endDay } = startAndEndOfWeek(date);
         // PART B - QUERY
         // let schedule: Schedule;
-        const schedule: ScheduleDto[] = await prisma.schedule.findMany({
+        const schedule = await prisma.schedule.findMany({
             where: {
                 AND: [
                     { startAt: { gte: startDay } },
@@ -36,11 +36,43 @@ export class READ {
                 startAt: "asc"
             },
             include: {
-                activity: true
+                activity: {
+                    include: {
+                        leaders: {
+                            select: {
+                                profile: {
+                                    select: {
+                                       id: true,
+                                       profileName: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         });
 
-        return schedule;
+        const formatSched: ScheduleDto[] = [];
+        schedule.forEach( el => {
+            let leader: any = el.activity.leaders;
+            leader = leader.map((el: { profile: any; }) => el.profile)
+            delete el.activity.leaders;
+            formatSched.push({
+                id: el.id,
+                activityId: el.activityId,
+                startAt: el.startAt,
+                endAt: el.endAt,
+                status: el.status,
+                createdAt: el.createdAt,
+                updatedAt: el.updatedAt,
+                activity: el.activity,
+                leaders: leader
+            } satisfies ScheduleDto)
+        })
+
+
+        return formatSched;
     }
 
     

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -1,13 +1,14 @@
 import { prisma } from "./prisma";
 import { startAndEndOfWeek } from "../utils/weekCalculator";
-import { ActivityTemplateModel, ScheduleModel } from "../generated/prisma/models";
+import { ActivityTemplate } from "../generated/prisma";
+import {ScheduleDto} from "../types/schedule.types";
 
 export class READ {
     /**
      * Purpose: returns the current schedule of the week
-     * @return (Schedule&Activity)[] OR undefined ==> see anyWeekSchedule(date: Date) for more details
+     * @return ScheduleDto[] --> {Schedule, activity: ActivityTemplate}[] ==> see anyWeekSchedule(date: Date) for more details
      */
-    static async currentSchedule(): Promise<ScheduleModel[] | undefined> {
+    static async currentSchedule(): Promise<ScheduleDto[]> {
         const nowDate: Date = new Date(); // for next weeks query we could just add 7? for the week after +14? usw.
         return await this.anyWeekSchedule(nowDate);
     }
@@ -16,41 +17,34 @@ export class READ {
     /**
      * Given any date, it returns the weeks schedule of the week the date is in.
      * @param date any valid date
-     * @return (Schedule&Activity)[] OR undefined
-     *      **SUCCESS**
-     *      --> array of that weeks schedule w/ the activities nested inside,
-     *              ordered by ascending dates (mondays actvities first, sundays last)
-     *      **FAIL**
-     *      --> undefined if no activities have been scheduled for the week you are looking for
+     * @return ScheduleDto[] --> {Schedule, activity: ActivityTemplate}[]
+     *      **SUCCESS** --> array filled with ScheduleDto objects
+     *      **FAIL** --> empty array
      */
-    static async anyWeekSchedule(date: Date): Promise<ScheduleModel[] | undefined> {//startDay: Date, endDay: Date
+    static async anyWeekSchedule(date: Date): Promise<ScheduleDto[]> {//
         const { startDay, endDay } = startAndEndOfWeek(date);
         // PART B - QUERY
-        let schedule: ScheduleModel[] | undefined;
-        if (startDay && endDay) {
-            schedule = await prisma.schedule.findMany({
-                where: {
-                    AND: [
-                        { startAt: { gte: startDay } },
-                        { startAt: { lte: endDay } }
-                    ]
-                },
-                orderBy: {
-                    startAt: "asc"
-                },
-                include: {
-                    activity: true
-                }
-            });
-        }
-        if (schedule?.length === 0) {
-            return undefined;
-        }
+        // let schedule: Schedule;
+        const schedule: ScheduleDto[] = await prisma.schedule.findMany({
+            where: {
+                AND: [
+                    { startAt: { gte: startDay } },
+                    { startAt: { lte: endDay } }
+                ]
+            },
+            orderBy: {
+                startAt: "asc"
+            },
+            include: {
+                activity: true
+            }
+        });
+
         return schedule;
     }
 
-
-    static async anyDaySchedule(date: Date): Promise<ScheduleModel[] | undefined> {
+    
+    static async anyDaySchedule(date: Date): Promise<ScheduleDto[]> {
         const startDay = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
         const endDay = new Date(Date.UTC(startDay.getUTCFullYear(), startDay.getUTCMonth(), startDay.getUTCDate() + 1));
         const schedule = await prisma.schedule.findMany({
@@ -95,7 +89,7 @@ export class READ {
     }
 
 
-    static async activityById(activityId: string): Promise<ActivityTemplateModel | null> {
+    static async activityById(activityId: string): Promise<ActivityTemplate | null> {
         const activity = await prisma.activityTemplate.findUnique({
             where: { id: activityId }
         });

--- a/server/src/routes/schedule.routes.ts
+++ b/server/src/routes/schedule.routes.ts
@@ -9,19 +9,19 @@ to get any weeks schedule: send a date in the week you want in the url
  */
 // current route: '/api/schedules'
 
-import express, {Router} from 'express';
+import  {Router} from 'express';
 import {controller} from "../controllers/schedule.controller";
 
 
-export const router: Router = express.Router();
+const scheduleRoutes: Router = Router();
 
 // returns the currents week schedule
-router.get('/current', controller.currentWeek ) // re-route to getSchedule function?
+scheduleRoutes.get('/current', controller.currentWeek ) // re-route to getSchedule function?
 
 
 
 // query: ?date=<some_date(default: today)&entireWeek=<boolean(default: true)>
-router.get('', controller.getSchedule )
+scheduleRoutes.get('', controller.getSchedule )
 
 /*
 CREATE:
@@ -32,6 +32,9 @@ UPDATE:
 DELETE:
 - weeks older than three?
  */
+
+
+export default scheduleRoutes
 
 
 

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -37,3 +37,5 @@ export type {
   Activity,
   TimeSlot,
 } from './activity.types';
+
+export type { ScheduleDto } from './schedule.types'

--- a/server/src/types/schedule.types.ts
+++ b/server/src/types/schedule.types.ts
@@ -1,6 +1,7 @@
-import { Schedule, ActivityTemplate } from '../generated/prisma';
+import { Schedule, ActivityTemplate, Profile } from '../generated/prisma';
 // import {Weekday, ActivityStatus} from '../db/prisma'
 
 export type ScheduleDto = Schedule &{
-    activity: ActivityTemplate
+    activity: ActivityTemplate,
+    leaders: Pick<Profile, 'id' | 'profileName'>[]
 };

--- a/server/src/types/schedule.types.ts
+++ b/server/src/types/schedule.types.ts
@@ -1,0 +1,6 @@
+import { Schedule, ActivityTemplate } from '../generated/prisma';
+// import {Weekday, ActivityStatus} from '../db/prisma'
+
+export type ScheduleDto = Schedule &{
+    activity: ActivityTemplate
+};

--- a/server/src/validators/schedule.validator.ts
+++ b/server/src/validators/schedule.validator.ts
@@ -1,0 +1,8 @@
+import * as z from "zod";
+
+export const ScheduleDateSchema = z.nullish(z.union([
+    z.iso.date(),
+    z.literal("today")
+])).default(new Date().toISOString());
+
+export const ScheduleBoolWeekSchema = z.nullish(z.stringbool()).default(true);


### PR DESCRIPTION
Updated both get requests to the current standard:

GET `/api/schedules/current` --> returns the currents weeks schedule, is a wrapper around the second GET-request

GET `/api/schedules?date=<some-date>&entireWeek=<boolean>`

**Valid `date` values**
Dates of the format *YYYY-MM-dd* or the string "today"
[See also zod.iso.date() type](https://zod.dev/api#iso-dates)

> Defaults to the current date

**Valid `entireWeek` values**
Any typical boolean values, I would prefer if we keep it to just *true* and *false*
[See also zod.stringbool()](https://zod.dev/api#stringbool)
> Defaults to *true*

> In General the route defaults to the currents weeks schedule