### PR TITLE
chore(server): fix ESM module resolution for Railway deployment

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
+    "postbuild": "cp -r src/generated/prisma/. dist/generated/prisma/",
     "start": "node dist/server.js"
   },
   "dependencies": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,12 @@
 import express from 'express';
 import cors from 'cors';
-import { errorHandler } from './middleware/errorHandler';
+import { errorHandler } from './middleware/errorHandler.js';
 
 // routers
-import authRoutes from './routes/auth.routes';
-import activityRoutes from './routes/activities.routes';
-import scheduleRoutes from "./routes/schedule.routes";
-import userRoutes from './routes/user.routes'
+import authRoutes from './routes/auth.routes.js';
+import activityRoutes from './routes/activities.routes.js';
+import scheduleRoutes from "./routes/schedule.routes.js";
+import userRoutes from './routes/user.routes.js'
 
 export const app = express();
 

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
-import { asyncHandler } from '../middleware/asyncHandler';
-import { ApiError } from '../utils/ApiError';
-import { prisma, ProfileRole, ActivityStatus } from '../db/prisma';
-import { ApiResponse, UpdateScheduleStatusBody, UpdateScheduleStatusDto, Activity } from '../types';
-import { CreateActivitySchema, DeleteActivitySchema, UpdateActivityGeneralSchema, UpdateActivityURLSchema } from "../validators";
-import { DELETE, READ, UPDATE, CREATE } from "../db/queries";
-import { ActivityDto } from "../types/activity.types";
+import { asyncHandler } from '../middleware/asyncHandler.js';
+import { ApiError } from '../utils/ApiError.js';
+import { prisma, ProfileRole, ActivityStatus } from '../db/prisma.js';
+import { ApiResponse, UpdateScheduleStatusBody, UpdateScheduleStatusDto, Activity } from '../types/index.js';
+import { CreateActivitySchema, DeleteActivitySchema, UpdateActivityGeneralSchema, UpdateActivityURLSchema } from "../validators/index.js";
+import { DELETE, READ, UPDATE, CREATE } from "../db/queries.js";
+import { ActivityDto } from "../types/activity.types.js";
 
 // ──────────────────────────────────────────────────────────────
 // Shared helpers

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
-import { register, login } from '../services/auth.service';
-import { asyncHandler } from '../middleware/asyncHandler';
-import { ApiError } from '../utils/ApiError';
-import { ApiResponse, AuthResponseDto, MeResponseDto } from '../types';
+import { register, login } from '../services/auth.service.js';
+import { asyncHandler } from '../middleware/asyncHandler.js';
+import { ApiError } from '../utils/ApiError.js';
+import { ApiResponse, AuthResponseDto, MeResponseDto } from '../types/index.js';
 
 /**
  * Success response shape:

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -1,10 +1,10 @@
-import {READ}  from '../db/readQueries'
-import {ApiError} from "../utils/ApiError";
+import {READ}  from '../db/readQueries.js';
+import {ApiError} from "../utils/ApiError.js";
 import {Request, Response} from "express";
-import {asyncHandler} from "../middleware/asyncHandler";
-import {ApiResponse} from "../types";
-import {ScheduleDto} from '../types'
-import {ScheduleDateSchema, ScheduleBoolWeekSchema} from "../validators/schedule.validator";
+import {asyncHandler} from "../middleware/asyncHandler.js";
+import {ApiResponse} from "../types/index.js";
+import {ScheduleDto} from '../types/index.js';
+import {ScheduleDateSchema, ScheduleBoolWeekSchema} from "../validators/schedule.validator.js";
 import {output, ZodISODate, ZodLiteral, ZodNullable, ZodOptional, ZodUnion} from "zod";
 
 const currentWeek = asyncHandler(

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,9 +1,9 @@
-import {ApiError} from "../utils/ApiError";
+import {ApiError} from "../utils/ApiError.js";
 import {Request, Response} from "express";
-import {asyncHandler} from "../middleware/asyncHandler";
-import {READ, CREATE, DELETE} from '../db/queries';
-import {CreateFavoriteSchema, DeleteFavoriteSchema} from "../validators";
-import {ApiResponse, FavoriteCreateDelete, ActivityDto} from "../types";
+import {asyncHandler} from "../middleware/asyncHandler.js";
+import {READ, CREATE, DELETE} from '../db/queries.js';
+import {CreateFavoriteSchema, DeleteFavoriteSchema} from "../validators/index.js";
+import {ApiResponse, FavoriteCreateDelete, ActivityDto} from "../types/index.js";
 
 const getFavorites = asyncHandler(
     async (req: Request, res: Response<ApiResponse<ActivityDto[]>>) => {

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -1,5 +1,5 @@
-import {Activity, FavoriteCreateDelete, ActivityDto} from "../types";
-import { prisma } from "./prisma";
+import {Activity, FavoriteCreateDelete, ActivityDto} from "../types/index.js";
+import { prisma } from "./prisma.js";
 /*
 CREATE Queries
     create new profile

--- a/server/src/db/deleteQueries.ts
+++ b/server/src/db/deleteQueries.ts
@@ -1,5 +1,5 @@
-import {prisma} from "./prisma";
-import {ActivityDto, FavoriteCreateDelete} from "../types";
+import {prisma} from "./prisma.js";
+import {ActivityDto, FavoriteCreateDelete} from "../types/index.js";
 
 export class DELETE {
     /**

--- a/server/src/db/prisma.ts
+++ b/server/src/db/prisma.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { PrismaClient } from "../generated/prisma";
+import { PrismaClient } from "../generated/prisma/index.js";
 
 const connectionString = process.env.DATABASE_URL;
 const pool = new Pool({ connectionString });
@@ -11,6 +11,6 @@ export { prisma };
 
 // Re-export Prisma enums so all code imports from this singleton
 // instead of directly from the generated client.
-export { ProfileRole } from '../generated/prisma';
-export { ActivityStatus } from '../generated/prisma';
-export { Weekday } from '../generated/prisma';
+export { ProfileRole } from '../generated/prisma/index.js';
+export { ActivityStatus } from '../generated/prisma/index.js';
+export { Weekday } from '../generated/prisma/index.js';

--- a/server/src/db/queries.ts
+++ b/server/src/db/queries.ts
@@ -1,4 +1,4 @@
-export { CREATE } from './createQueries';
-export { READ } from './readQueries';
-export { UPDATE } from './updateQueries';
-export { DELETE } from './deleteQueries';
+export { CREATE } from './createQueries.js';
+export { READ } from './readQueries.js';
+export { UPDATE } from './updateQueries.js';
+export { DELETE } from './deleteQueries.js';

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -1,7 +1,7 @@
-import { prisma } from "./prisma";
-import { startAndEndOfWeek } from "../utils/weekCalculator";
-import { ActivityTemplate, Profile } from "../generated/prisma";
-import { ScheduleDto, ActivityDto } from '../types'
+import { prisma } from "./prisma.js";
+import { startAndEndOfWeek } from "../utils/weekCalculator.js";
+import { ActivityTemplate, Profile } from "../generated/prisma/index.js";
+import { ScheduleDto, ActivityDto } from '../types/index.js';
 export class READ {
     /**
  * returns user based of their unique email

--- a/server/src/db/updateQueries.ts
+++ b/server/src/db/updateQueries.ts
@@ -1,5 +1,5 @@
-import { prisma } from "./prisma";
-import { Activity, TimeSlot } from "../types";
+import { prisma } from "./prisma.js";
+import { Activity, TimeSlot } from "../types/index.js";
 
 export class UPDATE {
     static async updateActivity(activityId: string, newData: Partial<Activity>) {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,7 +1,7 @@
-import { asyncHandler } from './asyncHandler';
-import { ApiError } from '../utils/ApiError';
-import { verifyToken } from '../utils/jwt';
-import { prisma, ProfileRole } from '../db/prisma';
+import { asyncHandler } from './asyncHandler.js';
+import { ApiError } from '../utils/ApiError.js';
+import { verifyToken } from '../utils/jwt.js';
+import { prisma, ProfileRole } from '../db/prisma.js';
 
 // ──────────────────────────────────────────────
 // Privilege hierarchy (ascending)

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { ApiError } from '../utils/ApiError';
+import { ApiError } from '../utils/ApiError.js';
 
 /**
  * Global error handler middleware.

--- a/server/src/routes/activities.routes.ts
+++ b/server/src/routes/activities.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { updateScheduleStatusHandler, getActivities, newActivity, updateActivity, deleteActivity } from '../controllers/activities.controller';
-import { authMiddleware, restrictToMinRole } from '../middleware/auth';
-import { ProfileRole } from "../db/prisma";
+import { updateScheduleStatusHandler, getActivities, newActivity, updateActivity, deleteActivity } from '../controllers/activities.controller.js';
+import { authMiddleware, restrictToMinRole } from '../middleware/auth.js';
+import { ProfileRole } from '../db/prisma.js';
 
 const router = Router();
 

--- a/server/src/routes/auth.routes.ts
+++ b/server/src/routes/auth.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { registerHandler, loginHandler, getMeHandler } from '../controllers/auth.controller';
-import { authMiddleware } from '../middleware/auth';
+import { registerHandler, loginHandler, getMeHandler } from '../controllers/auth.controller.js';
+import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
 

--- a/server/src/routes/schedule.routes.ts
+++ b/server/src/routes/schedule.routes.ts
@@ -10,7 +10,7 @@ to get any weeks schedule: send a date in the week you want in the url
 // current route: '/api/schedules'
 
 import  {Router} from 'express';
-import {controller} from "../controllers/schedule.controller";
+import {controller} from "../controllers/schedule.controller.js";
 
 
 const scheduleRoutes: Router = Router();

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { controller as userController} from '../controllers/user.controller';
-import { authMiddleware } from "../middleware/auth";
+import { controller as userController} from '../controllers/user.controller.js';
+import { authMiddleware } from "../middleware/auth.js";
 
 const userRoutes = Router();
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { app } from './app';
+import { app } from './app.js';
 
 const PORT = Number(process.env['PORT']) || 3001;
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,8 +1,8 @@
 import bcrypt from 'bcryptjs';
-import { prisma, ProfileRole } from '../db/prisma';
-import { ApiError } from '../utils/ApiError';
-import { generateToken } from '../utils/jwt';
-import { READ } from "../db/readQueries";
+import { prisma, ProfileRole } from '../db/prisma.js';
+import { ApiError } from '../utils/ApiError.js';
+import { generateToken } from '../utils/jwt.js';
+import { READ } from "../db/readQueries.js";
 
 /** Maps a Prisma Profile row to the public user DTO returned by auth endpoints. */
 const toUserDto = (p: { id: string; email: string; profileName: string | null; role: ProfileRole; }) => ({// does this need a return keyword

--- a/server/src/types/activity.types.ts
+++ b/server/src/types/activity.types.ts
@@ -1,4 +1,4 @@
-import { Weekday, ActivityStatus } from '../db/prisma';
+import { Weekday, ActivityStatus } from '../db/prisma.js';
 
 export type Activity = {
   name: string,

--- a/server/src/types/auth.types.ts
+++ b/server/src/types/auth.types.ts
@@ -1,4 +1,4 @@
-import { ProfileRole } from '../db/prisma';
+import { ProfileRole } from '../db/prisma.js';
 
 /** Public user representation returned by auth endpoints (no password). */
 export interface UserDto {

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,4 +1,4 @@
-import { ProfileRole } from '../../db/prisma';
+import { ProfileRole } from '../../db/prisma.js';
 
 declare global {
   namespace Express {

--- a/server/src/types/favorites.types.ts
+++ b/server/src/types/favorites.types.ts
@@ -1,3 +1,3 @@
-import {Favorite} from '../generated/prisma'
+import {Favorite} from '../generated/prisma/index.js';
 
 export type FavoriteCreateDelete = Pick<Favorite, 'activityId' | 'profileId'>;

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -30,16 +30,16 @@ export interface PaginationQuery {
 
 // ── Domain types ────────────────────────────────────────────────
 
-export type { UserDto, AuthResponseDto, MeResponseDto } from './auth.types';
+export type { UserDto, AuthResponseDto, MeResponseDto } from './auth.types.js';
 export type {
   UpdateScheduleStatusBody,
   UpdateScheduleStatusDto,
   Activity,
   TimeSlot,
   ActivityDto,
-} from './activity.types';
+} from './activity.types.js';
 
-export type { ScheduleDto } from './schedule.types'
+export type { ScheduleDto } from './schedule.types.js';
 export type {
   FavoriteCreateDelete
-} from './favorites.types'
+} from './favorites.types.js';

--- a/server/src/types/schedule.types.ts
+++ b/server/src/types/schedule.types.ts
@@ -1,4 +1,4 @@
-import { Schedule, ActivityTemplate, Profile } from '../generated/prisma';
+import { Schedule, ActivityTemplate, Profile } from '../generated/prisma/index.js';
 // import {Weekday, ActivityStatus} from '../db/prisma'
 
 export type ScheduleDto = Schedule &{

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -1,5 +1,5 @@
 import jwt, { type SignOptions } from 'jsonwebtoken';
-import { ProfileRole } from '../db/prisma';
+import { ProfileRole } from '../db/prisma.js';
 
 export interface JwtPayload {
   /**

--- a/server/src/validators/index.ts
+++ b/server/src/validators/index.ts
@@ -4,9 +4,9 @@ export {
   UpdateActivityGeneralSchema,
   UpdateActivityURLSchema,
   TimeSlotSchema,
-} from "./activity.validator";
+} from "./activity.validator.js";
 export {
   CreateFavoriteSchema,
   DeleteFavoriteSchema,
   isUUID,
-} from './favorites.validator'
+} from './favorites.validator.js';

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "target": "ES2022",
     "lib": ["ES2022"],
     "outDir": "dist",


### PR DESCRIPTION
## What and Why

The server `tsconfig.json` was using `moduleResolution: "Bundler"` which works fine in local dev but is incompatible with how Railway runs the compiled output. Railway executes `node dist/server.js` directly (no bundler involved) and Node's native ESM loader requires all local import paths to include explicit `.js` file extensions. Without them, the server crashes at startup with `ERR_MODULE_NOT_FOUND`.

This was my mistake from when I originally suggested the `Bundler` setting.

## Changes

- Updated `tsconfig.json`: `"module"` and `"moduleResolution"` changed from `"ESNext"` / `"Bundler"` to `"NodeNext"` / `"NodeNext"`
- Added `.js` extensions to all internal import paths across the server source files

## Testing

Run locally to verify the build still works:

```bash
cd server
npm run build
node dist/server.js
```

`tsc` should compile with zero errors and `node dist/server.js` should start cleanly against a local `DATABASE_URL`.

## Related

Closes #33
