### PR TITLE
Railway Deployment #c64dcd fix: run prisma generate before tsc

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "postbuild": "cp -r src/generated/prisma/. dist/generated/prisma/",
     "start": "node dist/server.js"
   },


### PR DESCRIPTION
## Problem

The build fails at BUILD_IMAGE because `npm run build` only runs `tsc`, but the Prisma client at `src/generated/prisma/` is never generated. When `tsc` runs, it cannot resolve `../generated/prisma/index.js`, causing multiple TS2307 errors across `src/db/prisma.ts`, `src/db/readQueries.ts`, and the types files, along with cascading TS7006 and TS2322 errors.

## Solution

Updated the `build` script in `server/package.json` from `"tsc"` to `"prisma generate && tsc"`. This ensures the Prisma client is generated before TypeScript compilation begins, providing the type declarations that `tsc` needs to resolve the Prisma imports.

### Changes
- **Modified** `server/package.json`

### Context
- **Deployment**: [#c64dcd](https://railway.com/project/771a5113-544f-47cb-8fe3-44922523608c/environment/94c1ce4b-1ee0-41a4-8f3c-1d5e415538ea/deployment/c64dcddc-20eb-433c-a51f-1a45058843bf)
- **Failed commit**: `a8a705e`

---
*Generated by [Railway](https://railway.com)*