### PR TITLE
fix(server): resolve Railway production build errors

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc",
+    "build": "prisma generate --no-engine && tsc",
     "postbuild": "cp -r src/generated/prisma/. dist/generated/prisma/",
     "start": "node dist/server.js"
   },

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -139,7 +139,7 @@ export const newActivity = asyncHandler(
     // If no leaders provided, assign the creator as the leader
     if (!newActivity.leaders || newActivity.leaders.length === 0) {
       if (req.user?.id) {
-        newActivity.leaders = [req.user.id];
+        newActivity.leaders = [req.user!.id];
       }
     }
 

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -70,7 +70,7 @@ export class READ {
         const formatSched: ScheduleDto[] = [];
         schedule.forEach(el => {
             let leader: any = el.activity.leaders ?? [];
-            leader = Array.isArray(leader) ? leader.map((el: { profile: any; }) => el.profile) : [];
+            leader = Array.isArray(leader) ? leader.map((el: { profile: { id: string; profileName: string } }) => el.profile) : [];
             (el.activity as any).leaders = undefined;
             formatSched.push({
                 id: el.id,
@@ -132,7 +132,7 @@ export class READ {
             }
         })
         //unsure about the satisfies keyword here: satisfies ActivityDto[]
-        return favorites.map(a => a.activity);
+        return favorites.map((a: { activity: ActivityDto }) => a.activity);
     }
 
     /**
@@ -155,7 +155,7 @@ export class READ {
                 }
             }
         });
-        return participants?.participations.map(el => el.profile);
+        return participants?.participations.map((el: { profile: Profile }) => el.profile);
     }
 
     // all activities updated after a given timestamp
@@ -198,7 +198,7 @@ export class READ {
             }
         })
         if (profilesFavorited) {
-            return profilesFavorited.favorites.map(el => el.profile);
+            return profilesFavorited.favorites.map((el: { profile: Profile }) => el.profile);
         } else {
             return [];
         }


### PR DESCRIPTION

## What

Fixes a series of TypeScript errors that only surface during production build on Railway (`tsc` in strict mode without a bundler).

## Changes

**`server/package.json`**
- Updated build command to run `prisma generate --no-engine` before `tsc` so the generated Prisma types exist when the compiler runs
- Start command on Railway handles `prisma migrate deploy` at runtime (not during build) to avoid `DATABASE_URL` not being available at image build time

**`server/src/controllers/activities.controller.ts`**
- Fixed `TS2322`: `req.user.id` typed as `string | undefined`,  changed to `req.user!.id` since auth middleware guarantees the user exists at this point

**`server/src/db/readQueries.ts`**
- Fixed `TS7006`: added explicit types to `.map()` callback parameters in `activitiesFavoritedBy`, `participantsOf`, and `profilesFavorited` (implicit `any` was previously hidden by `moduleResolution: Bundler`)

## Why now

These errors were introduced when `moduleResolution` was changed from `Bundler` to `NodeNext` in PR #62 to support Railway deployment. `Bundler` mode is more lenient with implicit types; `NodeNext` with `strict: true` surfaces them.

## Related

Part of #33 (Deployment)