### PR TITLE
feat: added CRUD for schedule

### DIFF
--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -6,6 +6,39 @@ import {ApiResponse} from "../types/index.js";
 import {ScheduleDto} from '../types/index.js';
 import {ScheduleDateSchema, ScheduleBoolWeekSchema} from "../validators/schedule.validator.js";
 import {output, ZodISODate, ZodLiteral, ZodNullable, ZodOptional, ZodUnion} from "zod";
+import { CREATE, UPDATE, DELETE } from "../db/queries.js";
+import { prisma, ProfileRole } from "../db/prisma.js";
+import { CreateScheduleSchema, UpdateScheduleSchema, ScheduleIdParamSchema } from "../validators/index.js";
+
+// Helper to assert activity existence & ownership for LEADERs
+async function assertActivityAccess(
+    activityId: string,
+    requesterId: string,
+    role: ProfileRole,
+) {
+    const activity = await prisma.activityTemplate.findUnique({
+        where: { id: activityId },
+        select: { id: true, name: true },
+    });
+
+    if (!activity) {
+        throw ApiError.notFound('Activity not found');
+    }
+
+    if (role === ProfileRole.LEADER) {
+        const ownership = await prisma.leaderActivity.findUnique({
+            where: {
+                profileId_activityId: { profileId: requesterId, activityId },
+            },
+        });
+
+        if (!ownership) {
+            throw ApiError.forbidden('You are not the leader of this activity');
+        }
+    }
+
+    return activity;
+}
 
 const currentWeek = asyncHandler(
     async (_req: Request, res: Response< ApiResponse< ScheduleDto[] > >) => {
@@ -53,9 +86,112 @@ const getSchedule = asyncHandler(
     }
 )
 
+const createSchedule = asyncHandler(async (
+    req: Request<{}, any, { activityId: string; startAt: string; endAt?: string | null; status?: string }>,
+    res: Response<ApiResponse<ScheduleDto>>
+) => {
+    let parsed;
+    try {
+        parsed = CreateScheduleSchema.parse(req.body);
+    } catch (err) {
+        throw ApiError.badRequest(`Invalid request body: ${err}`);
+    }
 
+    const { activityId, startAt, endAt, status } = parsed;
+
+    const activity = await prisma.activityTemplate.findUnique({
+        where: { id: activityId },
+        select: { id: true, defaultStatus: true }
+    });
+
+    if (!activity) {
+        throw ApiError.notFound('Activity not found');
+    }
+
+    const finalStatus = status || activity.defaultStatus;
+
+    const newSchedule = await CREATE.newSchedule({
+        activityId,
+        startAt,
+        endAt,
+        status: finalStatus
+    });
+
+    res.status(201).json({
+        status: 'success',
+        data: newSchedule
+    });
+});
+
+const updateSchedule = asyncHandler(async (
+    req: Request<{ scheduleId: string }, any, { startAt?: string; endAt?: string | null; status?: string }>,
+    res: Response<ApiResponse<ScheduleDto>>
+) => {
+    let parsedParams;
+    let parsedBody;
+    try {
+        parsedParams = ScheduleIdParamSchema.parse(req.params);
+        parsedBody = UpdateScheduleSchema.parse(req.body);
+    } catch (err) {
+        throw ApiError.badRequest(`Invalid parameters or request body: ${err}`);
+    }
+
+    const { scheduleId } = parsedParams;
+    const { id: requesterId, role } = req.user!;
+
+    const schedule = await prisma.schedule.findUnique({
+        where: { id: scheduleId },
+        select: { id: true, activityId: true }
+    });
+
+    if (!schedule) {
+        throw ApiError.notFound('Schedule not found');
+    }
+
+    await assertActivityAccess(schedule.activityId, requesterId, role);
+
+    const updated = await UPDATE.updateSchedule(scheduleId, parsedBody);
+
+    res.status(200).json({
+        status: 'success',
+        data: updated
+    });
+});
+
+const deleteSchedule = asyncHandler(async (
+    req: Request<{ scheduleId: string }>,
+    res: Response<ApiResponse<null>>
+) => {
+    let parsedParams;
+    try {
+        parsedParams = ScheduleIdParamSchema.parse(req.params);
+    } catch (err) {
+        throw ApiError.badRequest(`Invalid parameters: ${err}`);
+    }
+
+    const { scheduleId } = parsedParams;
+
+    const schedule = await prisma.schedule.findUnique({
+        where: { id: scheduleId },
+        select: { id: true }
+    });
+
+    if (!schedule) {
+        throw ApiError.notFound('Schedule not found');
+    }
+
+    await DELETE.deleteSchedule(scheduleId);
+
+    res.status(200).json({
+        status: 'success',
+        data: null
+    });
+});
 
 export const controller = {
     currentWeek,
-    getSchedule
+    getSchedule,
+    createSchedule,
+    updateSchedule,
+    deleteSchedule
 }

--- a/server/src/controllers/schedule.controller.ts
+++ b/server/src/controllers/schedule.controller.ts
@@ -99,22 +99,11 @@ const createSchedule = asyncHandler(async (
 
     const { activityId, startAt, endAt, status } = parsed;
 
-    const activity = await prisma.activityTemplate.findUnique({
-        where: { id: activityId },
-        select: { id: true, defaultStatus: true }
-    });
-
-    if (!activity) {
-        throw ApiError.notFound('Activity not found');
-    }
-
-    const finalStatus = status || activity.defaultStatus;
-
     const newSchedule = await CREATE.newSchedule({
         activityId,
         startAt,
         endAt,
-        status: finalStatus
+        status
     });
 
     res.status(201).json({

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -1,5 +1,5 @@
-import {Activity, FavoriteCreateDelete, ActivityDto} from "../types/index.js";
-import { prisma } from "./prisma.js";
+import {Activity, FavoriteCreateDelete, ActivityDto, ScheduleDto} from "../types/index.js";
+import { prisma, ActivityStatus } from "./prisma.js";
 /*
 CREATE Queries
     create new profile
@@ -64,5 +64,48 @@ export class CREATE{
             }
         });
         return activity;
+    }
+
+    static async newSchedule(data: {
+        activityId: string;
+        startAt: Date;
+        endAt?: Date | null;
+        status: ActivityStatus;
+    }): Promise<ScheduleDto> {
+        const schedule = await prisma.schedule.create({
+            data,
+            include: {
+                activity: {
+                    include: {
+                        leaders: {
+                            select: {
+                                profile: {
+                                    select: {
+                                        id: true,
+                                        profileName: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let leaders: any = schedule.activity.leaders ?? [];
+        leaders = Array.isArray(leaders) ? leaders.map((el: { profile: any; }) => el.profile) : [];
+        (schedule.activity as any).leaders = undefined;
+
+        return {
+            id: schedule.id,
+            activityId: schedule.activityId,
+            startAt: schedule.startAt,
+            endAt: schedule.endAt,
+            status: schedule.status,
+            createdAt: schedule.createdAt,
+            updatedAt: schedule.updatedAt,
+            activity: schedule.activity,
+            leaders
+        } satisfies ScheduleDto;
     }
 }

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -1,6 +1,7 @@
 import { Activity, FavoriteCreateDelete, ActivityDto, ScheduleDto } from "../types/index.js";
 import { prisma, ActivityStatus } from "./prisma.js";
 import { ApiError } from "../utils/ApiError.js";
+import { formatSchedule } from "./utils.js";
 /*
 CREATE Queries
     create new profile
@@ -71,10 +72,28 @@ export class CREATE {
         activityId: string;
         startAt: Date;
         endAt?: Date | null;
-        status: ActivityStatus;
+        status?: ActivityStatus;
     }): Promise<ScheduleDto> {
+        let finalStatus = data.status;
+
+        if (!finalStatus) {
+            const activity = await prisma.activityTemplate.findUnique({
+                where: { id: data.activityId },
+                select: { defaultStatus: true }
+            });
+            if (!activity) {
+                throw ApiError.notFound('Activity not found');
+            }
+            finalStatus = activity.defaultStatus;
+        }
+
         const schedule = await prisma.schedule.create({
-            data,
+            data: {
+                activityId: data.activityId,
+                startAt: data.startAt,
+                endAt: data.endAt,
+                status: finalStatus
+            },
             include: {
                 activity: {
                     include: {
@@ -93,21 +112,7 @@ export class CREATE {
             }
         });
 
-        let leaders: any = schedule.activity.leaders ?? [];
-        leaders = Array.isArray(leaders) ? leaders.map((el: { profile: any; }) => el.profile) : [];
-        (schedule.activity as any).leaders = undefined;
-
-        return {
-            id: schedule.id,
-            activityId: schedule.activityId,
-            startAt: schedule.startAt,
-            endAt: schedule.endAt,
-            status: schedule.status,
-            createdAt: schedule.createdAt,
-            updatedAt: schedule.updatedAt,
-            activity: schedule.activity,
-            leaders
-        } satisfies ScheduleDto;
+        return formatSchedule(schedule);
     }
 
     static async registerParticipation(profileId: string, scheduleId: string, activityId: string): Promise<number> {

--- a/server/src/db/deleteQueries.ts
+++ b/server/src/db/deleteQueries.ts
@@ -36,4 +36,12 @@ export class DELETE {
         });
         return res;
     }
+
+    static async deleteSchedule(scheduleId: string)
+    {
+        const res = await prisma.schedule.delete({
+            where: { id: scheduleId }
+        });
+        return res;
+    }
 }

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -2,6 +2,7 @@ import { prisma } from "./prisma.js";
 import { startAndEndOfWeek } from "../utils/weekCalculator.js";
 import { ActivityTemplate, Profile } from "../generated/prisma/index.js";
 import { ScheduleDto, ActivityDto } from '../types/index.js';
+import { formatSchedule } from "./utils.js";
 export class READ {
     /**
  * returns user based of their unique email
@@ -35,10 +36,9 @@ export class READ {
      *      **SUCCESS** --> array filled with ScheduleDto objects
      *      **FAIL** --> empty array
      */
-    static async anyWeekSchedule(date: Date): Promise<ScheduleDto[]> {//: Promise<ScheduleDto[]>
+    static async anyWeekSchedule(date: Date): Promise<ScheduleDto[]> {
         const { startDay, endDay } = startAndEndOfWeek(date);
-        // PART B - QUERY
-        // let schedule: Schedule;
+        
         const schedule = await prisma.schedule.findMany({
             where: {
                 AND: [
@@ -67,26 +67,7 @@ export class READ {
             }
         });
 
-        const formatSched: ScheduleDto[] = [];
-        schedule.forEach(el => {
-            let leader: any = el.activity.leaders ?? [];
-            leader = Array.isArray(leader) ? leader.map((el: { profile: { id: string; profileName: string } }) => el.profile) : [];
-            (el.activity as any).leaders = undefined;
-            formatSched.push({
-                id: el.id,
-                activityId: el.activityId,
-                startAt: el.startAt,
-                endAt: el.endAt,
-                status: el.status,
-                createdAt: el.createdAt,
-                updatedAt: el.updatedAt,
-                activity: el.activity,
-                leaders: leader
-            } satisfies ScheduleDto)
-        })
-
-
-        return formatSched;
+        return schedule.map(formatSchedule);
     }
 
 

--- a/server/src/db/updateQueries.ts
+++ b/server/src/db/updateQueries.ts
@@ -1,5 +1,5 @@
-import { prisma } from "./prisma.js";
-import { Activity, TimeSlot } from "../types/index.js";
+import { prisma, ActivityStatus } from "./prisma.js";
+import { Activity, TimeSlot, ScheduleDto } from "../types/index.js";
 
 export class UPDATE {
     static async updateActivity(activityId: string, newData: Partial<Activity>) {
@@ -72,5 +72,48 @@ export class UPDATE {
                 }
             },
         });
+    }
+
+    static async updateSchedule(scheduleId: string, data: {
+        startAt?: Date;
+        endAt?: Date | null;
+        status?: ActivityStatus;
+    }): Promise<ScheduleDto> {
+        const schedule = await prisma.schedule.update({
+            where: { id: scheduleId },
+            data,
+            include: {
+                activity: {
+                    include: {
+                        leaders: {
+                            select: {
+                                profile: {
+                                    select: {
+                                        id: true,
+                                        profileName: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let leaders: any = schedule.activity.leaders ?? [];
+        leaders = Array.isArray(leaders) ? leaders.map((el: { profile: any; }) => el.profile) : [];
+        (schedule.activity as any).leaders = undefined;
+
+        return {
+            id: schedule.id,
+            activityId: schedule.activityId,
+            startAt: schedule.startAt,
+            endAt: schedule.endAt,
+            status: schedule.status,
+            createdAt: schedule.createdAt,
+            updatedAt: schedule.updatedAt,
+            activity: schedule.activity,
+            leaders
+        } satisfies ScheduleDto;
     }
 }

--- a/server/src/db/updateQueries.ts
+++ b/server/src/db/updateQueries.ts
@@ -1,5 +1,6 @@
 import { prisma, ActivityStatus } from "./prisma.js";
 import { Activity, TimeSlot, ScheduleDto } from "../types/index.js";
+import { formatSchedule } from "./utils.js";
 
 export class UPDATE {
     static async updateActivity(activityId: string, newData: Partial<Activity>) {
@@ -100,20 +101,6 @@ export class UPDATE {
             }
         });
 
-        let leaders: any = schedule.activity.leaders ?? [];
-        leaders = Array.isArray(leaders) ? leaders.map((el: { profile: any; }) => el.profile) : [];
-        (schedule.activity as any).leaders = undefined;
-
-        return {
-            id: schedule.id,
-            activityId: schedule.activityId,
-            startAt: schedule.startAt,
-            endAt: schedule.endAt,
-            status: schedule.status,
-            createdAt: schedule.createdAt,
-            updatedAt: schedule.updatedAt,
-            activity: schedule.activity,
-            leaders
-        } satisfies ScheduleDto;
+        return formatSchedule(schedule);
     }
 }

--- a/server/src/db/utils.ts
+++ b/server/src/db/utils.ts
@@ -1,0 +1,27 @@
+import { ScheduleDto } from "../types/index.js";
+
+/**
+ * Shared utility to format a raw schedule from Prisma, extracting and flattening 
+ * leaders from `activity.leaders` and cleaning up the original nested leaders property.
+ */
+export function formatSchedule(schedule: any): ScheduleDto {
+    const leadersRaw = schedule.activity.leaders ?? [];
+    const leaders = Array.isArray(leadersRaw)
+        ? leadersRaw.map((el: { profile: any }) => el.profile)
+        : [];
+
+    const activity = { ...schedule.activity };
+    delete activity.leaders;
+
+    return {
+        id: schedule.id,
+        activityId: schedule.activityId,
+        startAt: schedule.startAt,
+        endAt: schedule.endAt,
+        status: schedule.status,
+        createdAt: schedule.createdAt,
+        updatedAt: schedule.updatedAt,
+        activity,
+        leaders
+    } satisfies ScheduleDto;
+}

--- a/server/src/routes/schedule.routes.ts
+++ b/server/src/routes/schedule.routes.ts
@@ -11,6 +11,8 @@ to get any weeks schedule: send a date in the week you want in the url
 
 import  {Router} from 'express';
 import {controller} from "../controllers/schedule.controller.js";
+import {authMiddleware, restrictToMinRole} from "../middleware/auth.js";
+import {ProfileRole} from "../db/prisma.js";
 
 
 const scheduleRoutes: Router = Router();
@@ -23,18 +25,39 @@ scheduleRoutes.get('/current', controller.currentWeek ) // re-route to getSchedu
 // query: ?date=<some_date(default: today)&entireWeek=<boolean(default: true)>
 scheduleRoutes.get('', controller.getSchedule )
 
-/*
-CREATE:
-- new Week
-READ: see aboveX
-UPDATE: --> activities.routes.ts
-- activity status
-DELETE:
-- weeks older than three?
- */
+// CREATE schedule: restrict to BOARD_MEMBER and above
+scheduleRoutes.post(
+    '',
+    authMiddleware,
+    restrictToMinRole(ProfileRole.BOARD_MEMBER),
+    controller.createSchedule
+);
+
+// UPDATE schedule: restrict to LEADER and above
+scheduleRoutes.put(
+    '/:scheduleId',
+    authMiddleware,
+    restrictToMinRole(ProfileRole.LEADER),
+    controller.updateSchedule
+);
+
+scheduleRoutes.patch(
+    '/:scheduleId',
+    authMiddleware,
+    restrictToMinRole(ProfileRole.LEADER),
+    controller.updateSchedule
+);
+
+// DELETE schedule: restrict to BOARD_MEMBER and above
+scheduleRoutes.delete(
+    '/:scheduleId',
+    authMiddleware,
+    restrictToMinRole(ProfileRole.BOARD_MEMBER),
+    controller.deleteSchedule
+);
 
 
-export default scheduleRoutes
+export default scheduleRoutes;
 
 
 

--- a/server/src/validators/index.ts
+++ b/server/src/validators/index.ts
@@ -10,3 +10,8 @@ export {
   DeleteFavoriteSchema,
   isUUID,
 } from './favorites.validator.js';
+export {
+  CreateScheduleSchema,
+  UpdateScheduleSchema,
+  ScheduleIdParamSchema,
+} from './schedule.validator.js';

--- a/server/src/validators/schedule.validator.ts
+++ b/server/src/validators/schedule.validator.ts
@@ -6,3 +6,22 @@ export const ScheduleDateSchema = z.nullish(z.union([
 ])).default(new Date().toISOString());
 
 export const ScheduleBoolWeekSchema = z.nullish(z.stringbool()).default(true);
+
+export const CreateScheduleSchema = z.object({
+    activityId: z.string().uuid(),
+    startAt: z.coerce.date(),
+    endAt: z.coerce.date().nullable().optional(),
+    status: z.enum(["ACTIVE", "INACTIVE", "CANCELLED", "DELAYED"]).optional(),
+});
+
+export const UpdateScheduleSchema = z.object({
+    startAt: z.coerce.date().optional(),
+    endAt: z.coerce.date().nullable().optional(),
+    status: z.enum(["ACTIVE", "INACTIVE", "CANCELLED", "DELAYED"]).optional(),
+}).refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field to update must be provided",
+});
+
+export const ScheduleIdParamSchema = z.object({
+    scheduleId: z.string().uuid(),
+});


### PR DESCRIPTION

Added CRUD capabilities (Create, Update, Delete) to the `Schedule` resource, integrating appropriate role-based access control and leader activity ownership checks.


## Authorization and Security Rules
* **POST /api/schedules**: Restricted to `BOARD_MEMBER` and above.
* **PUT/PATCH /api/schedules/:scheduleId**: Restricted to `LEADER` and above.
  * Requesters with the `LEADER` role must be assigned as a leader of the activity associated with the schedule. `BOARD_MEMBER` and `ADMIN` skip this check.
  * Updating `activityId` is not supported (schedule-to-activity relationships are immutable). Only `startAt`, `endAt`, and `status` can be modified.
* **DELETE /api/schedules/:scheduleId**: Restricted to `BOARD_MEMBER` and above.


## Key Changes

### Database Query Layer
* **createQueries.ts**: Implemented `CREATE.newSchedule` which inserts a new schedule and returns it formatted as a `ScheduleDto` containing activity and leader details.
* **updateQueries.ts**: Implemented `UPDATE.updateSchedule` to partially update schedules (`startAt`, `endAt`, `status`).
* **deleteQueries.ts**: Implemented `DELETE.deleteSchedule` to delete a schedule by its unique ID.

### Request Validation Layer (Zod)
* **schedule.validator.ts**: Added Zod validation schemas:
  * `CreateScheduleSchema`: Validates creation fields (`activityId`, `startAt`, `endAt`, `status`).
  * `UpdateScheduleSchema`: Validates updateable fields (`startAt`, `endAt`, `status`).
  * `ScheduleIdParamSchema`: Validates that `scheduleId` in path parameters is a valid UUID.
* **index.ts**: Added barrel exports for the new schemas.

### Controller & Routing Layer
* **schedule.controller.ts**:
  * Implemented `assertActivityAccess` to verify activity template existence and restrict non-assigned leaders from modifying schedules.
  * Added handlers `createSchedule`, `updateSchedule`, and `deleteSchedule`.
* **schedule.routes.ts**: Registered `POST /`, `PUT /:scheduleId`, `PATCH /:scheduleId`, and `DELETE /:scheduleId` with standard hierarchy role guards.