### PR TITLE
feat: added attendee list view for leader

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import LoginPage    from './pages/LoginPage.jsx'
 import RegisterPage from './pages/RegisterPage.jsx'
 import ActivityFormPage from './pages/ActivityFormPage.jsx'
 import SchedulePage from './pages/SchedulePage.jsx'
+import ActivityDetailPage from './pages/ActivityDetailPage.jsx'
 
 // ── ProtectedRoute ────────────────────────────────────────────
 // Wraps any route that requires login.
@@ -95,7 +96,7 @@ function AppRoutes() {
           <Route path="/register"       element={<RegisterPage />} />
           <Route path="/activities" element={<ActivitiesPage />} />
           <Route path="/activities/new" element={<ProtectedRoute><ActivityFormPage /></ProtectedRoute>} />
-          <Route path="/activities/:id" element={<Placeholder title="Activity Detail" />} />
+          <Route path="/activities/:id" element={<ActivityDetailPage />} />
           <Route path="/activities/:id/edit" element={<ProtectedRoute><ActivityFormPage /></ProtectedRoute>} />
 
           {/* Protected route — must be logged in */}

--- a/client/src/pages/ActivitiesPage.jsx
+++ b/client/src/pages/ActivitiesPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import { fetchFavorites, addFavorite, removeFavorite, } from '../services/FavoritesService.js'
 import Card from '../components/ui/Card.jsx'
@@ -181,7 +181,23 @@ export default function ActivitiesPage() {
                   : '♡'}
               </button>
               <h2 style={{ marginBottom: '8px' }}>
-                {activity.name}
+                <Link
+                  to={`/activities/${activity.id}`}
+                  style={{
+                    color: 'var(--color-text)',
+                    textDecoration: 'none',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.target.style.textDecoration = 'underline'
+                    e.target.style.color = 'var(--color-primary-dark)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.target.style.textDecoration = 'none'
+                    e.target.style.color = 'var(--color-text)'
+                  }}
+                >
+                  {activity.name}
+                </Link>
               </h2>
 
               {/* Activity details */}

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import Card from '../components/ui/Card.jsx'
@@ -17,17 +17,16 @@ export default function ActivityDetailPage() {
   useEffect(() => {
     async function loadActivity() {
       try {
-        const response = await fetch('/api/activities')
+        const headers = {}
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`
+        }
+        const response = await fetch(`/api/activities/${id}`, { headers })
         if (!response.ok) {
           throw new Error('Failed to fetch activity details')
         }
         const result = await response.json()
-        const found = result.data.find(act => act.id === id)
-        if (!found) {
-          setError('Activity not found')
-        } else {
-          setActivity(found)
-        }
+        setActivity(result.data)
       } catch (err) {
         setError(err.message)
       } finally {
@@ -35,14 +34,17 @@ export default function ActivityDetailPage() {
       }
     }
     loadActivity()
-  }, [id])
+  }, [id, token])
 
   // ── Determine if user is a leader/admin for this activity ────
-  const isLeader = isAuthenticated && (
-    user.role === 'ADMIN' ||
-    user.role === 'BOARD_MEMBER' ||
-    (user.role === 'LEADER' && activity?.leaders?.some(l => l.profileId === user.id))
-  )
+  const isLeader = useMemo(() => {
+    if (!isAuthenticated || !activity) return false
+    return (
+      user.role === 'ADMIN' ||
+      user.role === 'BOARD_MEMBER' ||
+      (user.role === 'LEADER' && activity.leaders?.some(l => l.profileId === user.id))
+    )
+  }, [isAuthenticated, user, activity])
 
   // ── Fetch Attendee List (Leaders/Admins only) ────────────────
   useEffect(() => {
@@ -106,7 +108,7 @@ export default function ActivityDetailPage() {
             </p>
           </div>
           {/* Action buttons if logged in */}
-          {isAuthenticated && (user.role === 'ADMIN' || user.role === 'BOARD_MEMBER' || (user.role === 'LEADER' && activity.leaders?.some(l => l.profileId === user.id))) && (
+          {isAuthenticated && (user.role === 'ADMIN' || user.role === 'BOARD_MEMBER') && (
             <Button as={Link} to={`/activities/${activity.id}/edit`} variant="outline" size="sm">
               Edit Activity
             </Button>

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -11,6 +11,7 @@ export default function ActivityDetailPage() {
   const { isAuthenticated, user, token } = useAuth()
   const [activity, setActivity] = useState(null)
   const [participantData, setParticipantData] = useState(null)
+  const [participantError, setParticipantError] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
@@ -54,7 +55,7 @@ export default function ActivityDetailPage() {
                 setParticipantData(partResult.data)
               }
             } catch (partErr) {
-              // Silently ignore participant loading errors so the main details still render
+              setParticipantError('Could not load attendee list. Try refreshing.')
             }
           }
         }
@@ -95,28 +96,6 @@ export default function ActivityDetailPage() {
           <h2 style={{ color: 'var(--color-danger)', marginBottom: '12px' }}>Error</h2>
           <p style={{ marginBottom: '24px' }}>{error || 'Activity not found.'}</p>
           <Button onClick={() => navigate('/activities')}>Back to Activities</Button>
-          {activity.defaultStatus === 'CANCELLED' && (
-            <div style={{
-              background: 'var(--color-danger-light)',
-              borderLeft: '6px solid var(--color-danger)',
-              color: 'var(--color-danger)',
-              padding: 'var(--space-4) var(--space-6)',
-              borderRadius: 'var(--radius-md)',
-              marginBottom: 'var(--space-6)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-3)',
-              fontWeight: 700,
-            }}>
-              <span>⚠️</span>
-              <div>
-                <p style={{ margin: 0, fontWeight: 700 }}>This activity has been cancelled.</p>
-                <p style={{ margin: '2px 0 0', fontWeight: 400, fontSize: 'var(--text-sm)', opacity: 0.9 }}>
-                  No active schedules or future sessions will run until the activity is reactivated.
-                </p>
-              </div>
-            </div>
-          )}
         </Card>
       </div>
     )
@@ -128,6 +107,29 @@ export default function ActivityDetailPage() {
       <Link to="/activities" style={{ color: 'var(--color-primary-dark)', textDecoration: 'none', fontWeight: 600, display: 'inline-flex', alignItems: 'center', marginBottom: 'var(--space-4)' }}>
         ← Back to Activities
       </Link>
+
+      {activity.defaultStatus === 'CANCELLED' && (
+        <div style={{
+          background: 'var(--color-danger-light)',
+          borderLeft: '6px solid var(--color-danger)',
+          color: 'var(--color-danger)',
+          padding: 'var(--space-4) var(--space-6)',
+          borderRadius: 'var(--radius-md)',
+          marginBottom: 'var(--space-6)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          fontWeight: 700,
+        }}>
+          <span>⚠️</span>
+          <div>
+            <p style={{ margin: 0, fontWeight: 700 }}>This activity has been cancelled.</p>
+            <p style={{ margin: '2px 0 0', fontWeight: 400, fontSize: 'var(--text-sm)', opacity: 0.9 }}>
+              No active schedules or future sessions will run until the activity is reactivated.
+            </p>
+          </div>
+        </div>
+      )}
 
       <Card padding="md" shadow="md" style={{ marginBottom: 'var(--space-6)' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: '16px' }}>
@@ -186,6 +188,12 @@ export default function ActivityDetailPage() {
           <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem', marginBottom: '20px' }}>
             Registered participants for all schedules of this activity. Only visible to leaders.
           </p>
+
+          {participantError && (
+            <p style={{ color: 'var(--color-danger)', fontSize: '0.9rem', marginBottom: '16px' }}>
+              {participantError}
+            </p>
+          )}
 
           {!participantData || participantData.schedules?.length === 0 ? (
             <p style={{ fontStyle: 'italic', color: 'var(--color-text-muted)' }}>No schedules found for this activity.</p>

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -13,28 +13,59 @@ export default function ActivityDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  // ── Fetch Activity Details ───────────────────────────────────
+  // ── Fetch Activity & Participants ────────────────────────────
   useEffect(() => {
-    async function loadActivity() {
+    async function loadData() {
       try {
+        setLoading(true)
+        setError(null)
+
         const headers = {}
         if (token) {
           headers['Authorization'] = `Bearer ${token}`
         }
+
         const response = await fetch(`/api/activities/${id}`, { headers })
         if (!response.ok) {
           throw new Error('Failed to fetch activity details')
         }
+
         const result = await response.json()
-        setActivity(result.data)
+        const activityData = result.data
+        setActivity(activityData)
+
+        // Fetch participants in the same flow if the user is authorized (leader/admin)
+        if (isAuthenticated && token && activityData) {
+          const isUserLeader =
+            user.role === 'ADMIN' ||
+            user.role === 'BOARD_MEMBER' ||
+            (user.role === 'LEADER' && activityData.leaders?.some(l => l.profileId === user.id))
+
+          if (isUserLeader) {
+            try {
+              const partResponse = await fetch(`/api/activities/${id}/participants`, {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              })
+              if (partResponse.ok) {
+                const partResult = await partResponse.json()
+                setParticipantData(partResult.data)
+              }
+            } catch (partErr) {
+              // Silently ignore participant loading errors so the main details still render
+            }
+          }
+        }
       } catch (err) {
         setError(err.message)
       } finally {
         setLoading(false)
       }
     }
-    loadActivity()
-  }, [id, token])
+
+    loadData()
+  }, [id, token, isAuthenticated, user])
 
   // ── Determine if user is a leader/admin for this activity ────
   const isLeader = useMemo(() => {
@@ -42,33 +73,11 @@ export default function ActivityDetailPage() {
     return (
       user.role === 'ADMIN' ||
       user.role === 'BOARD_MEMBER' ||
+      // NOTE: ActivityDto.leaders uses { profileId, activityId } shape.
+      // If normalized to { id, profileName } (see issue #XX), change to l.id === user.id
       (user.role === 'LEADER' && activity.leaders?.some(l => l.profileId === user.id))
     )
   }, [isAuthenticated, user, activity])
-
-  // ── Fetch Attendee List (Leaders/Admins only) ────────────────
-  useEffect(() => {
-    if (!isLeader) return
-
-    async function loadParticipants() {
-      try {
-        const response = await fetch(`/api/activities/${id}/participants`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        })
-        if (response.ok) {
-          const result = await response.json()
-          setParticipantData(result.data)
-        } else {
-          console.error('Failed to load participants', response.statusText)
-        }
-      } catch (err) {
-        console.error('Error fetching participants:', err)
-      }
-    }
-    loadParticipants()
-  }, [id, isLeader, token])
 
   if (loading) {
     return (

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -1,0 +1,222 @@
+import React, { useState, useEffect } from 'react'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext.jsx'
+import Card from '../components/ui/Card.jsx'
+import Button from '../components/ui/Button.jsx'
+
+export default function ActivityDetailPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { isAuthenticated, user, token } = useAuth()
+  const [activity, setActivity] = useState(null)
+  const [participantData, setParticipantData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // ── Fetch Activity Details ───────────────────────────────────
+  useEffect(() => {
+    async function loadActivity() {
+      try {
+        const response = await fetch('/api/activities')
+        if (!response.ok) {
+          throw new Error('Failed to fetch activity details')
+        }
+        const result = await response.json()
+        const found = result.data.find(act => act.id === id)
+        if (!found) {
+          setError('Activity not found')
+        } else {
+          setActivity(found)
+        }
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadActivity()
+  }, [id])
+
+  // ── Determine if user is a leader/admin for this activity ────
+  const isLeader = isAuthenticated && (
+    user.role === 'ADMIN' ||
+    user.role === 'BOARD_MEMBER' ||
+    (user.role === 'LEADER' && activity?.leaders?.some(l => l.profileId === user.id))
+  )
+
+  // ── Fetch Attendee List (Leaders/Admins only) ────────────────
+  useEffect(() => {
+    if (!isLeader) return
+
+    async function loadParticipants() {
+      try {
+        const response = await fetch(`/api/activities/${id}/participants`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+        if (response.ok) {
+          const result = await response.json()
+          setParticipantData(result.data)
+        } else {
+          console.error('Failed to load participants', response.statusText)
+        }
+      } catch (err) {
+        console.error('Error fetching participants:', err)
+      }
+    }
+    loadParticipants()
+  }, [id, isLeader, token])
+
+  if (loading) {
+    return (
+      <div style={{ padding: 'var(--space-6)', maxWidth: '900px', margin: '0 auto', textAlign: 'center' }}>
+        <p style={{ color: 'var(--color-text-muted)', fontSize: '1.1rem' }}>Loading activity...</p>
+      </div>
+    )
+  }
+
+  if (error || !activity) {
+    return (
+      <div style={{ padding: 'var(--space-6)', maxWidth: '900px', margin: '0 auto' }}>
+        <Card padding="md" border="accent" style={{ textAlign: 'center' }}>
+          <h2 style={{ color: 'var(--color-danger)', marginBottom: '12px' }}>Error</h2>
+          <p style={{ marginBottom: '24px' }}>{error || 'Activity not found.'}</p>
+          <Button onClick={() => navigate('/activities')}>Back to Activities</Button>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: 'var(--space-6)', maxWidth: '900px', margin: '0 auto' }}>
+      {/* Back button */}
+      <Link to="/activities" style={{ color: 'var(--color-primary-dark)', textDecoration: 'none', fontWeight: 600, display: 'inline-flex', alignItems: 'center', marginBottom: 'var(--space-4)' }}>
+        ← Back to Activities
+      </Link>
+
+      <Card padding="md" shadow="md" style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: '16px' }}>
+          <div>
+            <h1 style={{ fontFamily: 'Georgia, serif', fontSize: '2.5rem', marginBottom: '8px', color: 'var(--color-text)' }}>
+              {activity.name}
+            </h1>
+            <p style={{ color: 'var(--color-text-muted)', fontSize: '1.1rem', marginBottom: '16px', fontStyle: 'italic' }}>
+              {activity.description || 'No description provided.'}
+            </p>
+          </div>
+          {/* Action buttons if logged in */}
+          {isAuthenticated && (user.role === 'ADMIN' || user.role === 'BOARD_MEMBER' || (user.role === 'LEADER' && activity.leaders?.some(l => l.profileId === user.id))) && (
+            <Button as={Link} to={`/activities/${activity.id}/edit`} variant="outline" size="sm">
+              Edit Activity
+            </Button>
+          )}
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '16px', marginTop: '16px', borderTop: '1px solid var(--color-border)', paddingTop: '16px' }}>
+          <div>
+            <span style={{ fontWeight: 700, textTransform: 'uppercase', fontSize: '0.75rem', letterSpacing: '1px', color: 'var(--color-text-muted)' }}>Location</span>
+            <p style={{ fontSize: '1.1rem', marginTop: '4px', fontWeight: 500 }}>{activity.location}</p>
+          </div>
+          <div>
+            <span style={{ fontWeight: 700, textTransform: 'uppercase', fontSize: '0.75rem', letterSpacing: '1px', color: 'var(--color-text-muted)' }}>Max Capacity</span>
+            <p style={{ fontSize: '1.1rem', marginTop: '4px', fontWeight: 500 }}>{activity.maxCapacity ?? 'Unlimited'}</p>
+          </div>
+        </div>
+
+        {/* Time slots */}
+        {activity.timeSlots?.length > 0 && (
+          <div style={{ marginTop: '24px', borderTop: '1px solid var(--color-border)', paddingTop: '16px' }}>
+            <span style={{ fontWeight: 700, textTransform: 'uppercase', fontSize: '0.75rem', letterSpacing: '1px', color: 'var(--color-text-muted)' }}>Scheduled Time Slots</span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '8px' }}>
+              {activity.timeSlots.map(slot => (
+                <div key={slot.id} style={{ display: 'flex', alignItems: 'center', gap: '8px', background: 'var(--color-surface)', padding: '8px 12px', borderRadius: '4px', width: 'fit-content' }}>
+                  <span style={{ fontWeight: 600, color: 'var(--color-primary-dark)' }}>{slot.weekday}</span>
+                  <span style={{ color: 'var(--color-text-muted)' }}>•</span>
+                  <span>
+                    {new Date(slot.startTime).toISOString().slice(11, 16)} - {new Date(slot.endTime).toISOString().slice(11, 16)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </Card>
+
+      {/* Leader attendee list view */}
+      {isLeader && (
+        <Card padding="md" shadow="md" border="accent" style={{ background: '#fcfdfa' }}>
+          <h2 style={{ fontFamily: 'Georgia, serif', fontSize: '1.8rem', marginBottom: '6px', color: 'var(--color-primary-dark)' }}>
+            Attendee List
+          </h2>
+          <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem', marginBottom: '20px' }}>
+            Registered participants for all schedules of this activity. Only visible to leaders.
+          </p>
+
+          {!participantData || participantData.schedules?.length === 0 ? (
+            <p style={{ fontStyle: 'italic', color: 'var(--color-text-muted)' }}>No schedules found for this activity.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+              {participantData.schedules.map(schedule => {
+                const dateObj = new Date(schedule.startAt)
+                const formattedDate = dateObj.toLocaleDateString('en-US', {
+                  weekday: 'long',
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })
+                const formattedTime = dateObj.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+                return (
+                  <div key={schedule.scheduleId} style={{ border: '1px solid var(--color-border)', borderRadius: '6px', overflow: 'hidden', background: '#ffffff' }}>
+                    {/* Schedule Header */}
+                    <div style={{ background: 'var(--color-primary-light)', padding: '12px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
+                      <div>
+                        <h3 style={{ fontSize: '1.05rem', fontWeight: 700, margin: 0, color: 'var(--color-primary-dark)' }}>
+                          {formattedDate} at {formattedTime}
+                        </h3>
+                        {schedule.status !== 'ACTIVE' && (
+                          <span style={{
+                            display: 'inline-block',
+                            fontSize: '0.75rem',
+                            fontWeight: 700,
+                            color: schedule.status === 'CANCELLED' ? 'var(--color-danger)' : '#d4ac0d',
+                            marginTop: '4px',
+                            textTransform: 'uppercase'
+                          }}>
+                            {schedule.status}
+                          </span>
+                        )}
+                      </div>
+                      <span style={{ fontSize: '0.85rem', fontWeight: 600, background: '#ffffff', padding: '4px 10px', borderRadius: '12px', border: '1px solid var(--color-border)' }}>
+                        {schedule.participants.length} Registered
+                      </span>
+                    </div>
+
+                    {/* Participant List */}
+                    <div style={{ padding: '12px 16px' }}>
+                      {schedule.participants.length === 0 ? (
+                        <p style={{ fontStyle: 'italic', color: 'var(--color-text-muted)', fontSize: '0.9rem', margin: '4px 0' }}>No registered participants yet.</p>
+                      ) : (
+                        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                          {schedule.participants.map((participant, pIndex) => (
+                            <li key={participant.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: pIndex < schedule.participants.length - 1 ? '8px' : '0', borderBottom: pIndex < schedule.participants.length - 1 ? '1px solid var(--color-surface)' : 'none' }}>
+                              <div>
+                                <span style={{ fontWeight: 600, color: 'var(--color-text)' }}>{participant.profileName}</span>
+                                <span style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem', marginLeft: '8px' }}>({participant.email})</span>
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import Button from '../components/ui/Button.jsx'
 
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 
 // ─────────────────────────────────────────────────────────────
@@ -473,7 +473,27 @@ return displayedActivities.filter(
                         fontWeight: 700,
                       }}
                     >
-                      {activity.title}
+                      {activity.activityId ? (
+                        <Link
+                          to={`/activities/${activity.activityId}`}
+                          style={{
+                            color: 'inherit',
+                            textDecoration: 'none',
+                          }}
+                          onMouseEnter={(e) => {
+                            e.target.style.textDecoration = 'underline'
+                            e.target.style.color = 'var(--color-primary-dark)'
+                          }}
+                          onMouseLeave={(e) => {
+                            e.target.style.textDecoration = 'none'
+                            e.target.style.color = 'inherit'
+                          }}
+                        >
+                          {activity.title}
+                        </Link>
+                      ) : (
+                        activity.title
+                      )}
                     </p>
 
                     {/* Sport */}

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -320,3 +320,17 @@ export const getActivityParticipants = asyncHandler(async (
   })
 })
 
+export const getActivityById = asyncHandler(async (
+  req: Request<{ activityId: string }>,
+  res: Response<ApiResponse<any>>
+) => {
+  const { activityId } = req.params
+  if (!isUUID(activityId)) {
+    throw ApiError.badRequest('Invalid activityId format')
+  }
+  const activity = await READ.activityById(activityId)
+  if (!activity) throw ApiError.notFound('Activity not found')
+  res.status(200).json({ status: 'success', data: activity })
+})
+
+

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { ApiError } from '../utils/ApiError.js';
 import { prisma, ProfileRole, ActivityStatus } from '../db/prisma.js';
-import { ApiResponse, UpdateScheduleStatusBody, UpdateScheduleStatusDto, Activity, ActivityDto } from '../types/index.js';
+import { ApiResponse, UpdateScheduleStatusBody, UpdateScheduleStatusDto, Activity, ActivityDto, ActivityParticipantsDto } from '../types/index.js';
 import { CreateActivitySchema, DeleteActivitySchema, UpdateActivityGeneralSchema, UpdateActivityURLSchema, isUUID } from "../validators/index.js";
 import { DELETE, READ, UPDATE, CREATE } from "../db/queries.js";
 
@@ -260,7 +260,7 @@ export const unregisterParticipation = asyncHandler(async (
 
 export const getActivityParticipants = asyncHandler(async (
   req: Request<{ activityId: string }>,
-  res: Response<ApiResponse<any>>
+  res: Response<ApiResponse<ActivityParticipantsDto>>
 ) => {
   const { activityId } = req.params
   const { id: requesterId, role } = req.user!
@@ -298,6 +298,8 @@ export const getActivityParticipants = asyncHandler(async (
   })
 
   // 3. Format response
+  // NOTE: Email addresses are intentionally exposed here to activity leaders and admins
+  // to facilitate direct communication, coordinates, and urgent notices with registered participants.
   const formattedSchedules = schedules.map(s => ({
     scheduleId: s.id,
     startAt: s.startAt,
@@ -322,7 +324,7 @@ export const getActivityParticipants = asyncHandler(async (
 
 export const getActivityById = asyncHandler(async (
   req: Request<{ activityId: string }>,
-  res: Response<ApiResponse<any>>
+  res: Response<ApiResponse<ActivityDto>>
 ) => {
   const { activityId } = req.params
   if (!isUUID(activityId)) {

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -257,3 +257,66 @@ export const unregisterParticipation = asyncHandler(async (
 
   res.status(200).json({ status: 'success', data: { participantCount } })
 })
+
+export const getActivityParticipants = asyncHandler(async (
+  req: Request<{ activityId: string }>,
+  res: Response<ApiResponse<any>>
+) => {
+  const { activityId } = req.params
+  const { id: requesterId, role } = req.user!
+
+  if (!isUUID(activityId)) {
+    throw ApiError.badRequest('Invalid activityId format')
+  }
+
+  // 1. Verify existence + leadership/admin access
+  const activity = await assertActivityAccess(activityId, requesterId, role)
+
+  // 2. Fetch schedules and their participants
+  const schedules = await prisma.schedule.findMany({
+    where: { activityId },
+    select: {
+      id: true,
+      startAt: true,
+      endAt: true,
+      status: true,
+      participations: {
+        select: {
+          profile: {
+            select: {
+              id: true,
+              profileName: true,
+              email: true,
+            }
+          }
+        }
+      }
+    },
+    orderBy: {
+      startAt: 'asc'
+    }
+  })
+
+  // 3. Format response
+  const formattedSchedules = schedules.map(s => ({
+    scheduleId: s.id,
+    startAt: s.startAt,
+    endAt: s.endAt,
+    status: s.status,
+    participants: s.participations.map(p => ({
+      id: p.profile.id,
+      profileName: p.profile.profileName || 'No Name',
+      email: p.profile.email
+    }))
+  }))
+
+  res.status(200).json({
+    status: 'success',
+    data: {
+      activityId: activity.id,
+      activityName: activity.name,
+      schedules: formattedSchedules
+    }
+  })
+})
+

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -273,29 +273,7 @@ export const getActivityParticipants = asyncHandler(async (
   const activity = await assertActivityAccess(activityId, requesterId, role)
 
   // 2. Fetch schedules and their participants
-  const schedules = await prisma.schedule.findMany({
-    where: { activityId },
-    select: {
-      id: true,
-      startAt: true,
-      endAt: true,
-      status: true,
-      participations: {
-        select: {
-          profile: {
-            select: {
-              id: true,
-              profileName: true,
-              email: true,
-            }
-          }
-        }
-      }
-    },
-    orderBy: {
-      startAt: 'asc'
-    }
-  })
+  const schedules = await READ.activityParticipants(activityId)
 
   // 3. Format response
   // NOTE: Email addresses are intentionally exposed here to activity leaders and admins

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -203,5 +203,31 @@ export class READ {
         return record !== null;
     }
 
+    static async activityParticipants(activityId: string) {
+        return await prisma.schedule.findMany({
+            where: { activityId },
+            select: {
+                id: true,
+                startAt: true,
+                endAt: true,
+                status: true,
+                participations: {
+                    select: {
+                        profile: {
+                            select: {
+                                id: true,
+                                profileName: true,
+                                email: true,
+                            }
+                        }
+                    }
+                }
+            },
+            orderBy: {
+                startAt: 'asc'
+            }
+        });
+    }
+
 
 }

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -142,7 +142,7 @@ export class READ {
     // all activities updated after a given timestamp
     // static async activitiesUpdatedAfter(lastRequest: Date){}
 
-    static async activityById(activityId: string) {
+    static async activityById(activityId: string): Promise<ActivityDto | null> {
         const activity = await prisma.activityTemplate.findUnique({
             where: { id: activityId },
             include: {
@@ -150,19 +150,19 @@ export class READ {
                 leaders: true
             }
         });
-        return activity;
+        return activity as ActivityDto | null;
     }
     /**
      * just returns all activityTemplates
      */
-    static async allActivities() {
+    static async allActivities(): Promise<ActivityDto[]> {
         let activities = await prisma.activityTemplate.findMany({
             include: {
                 timeSlots: true,
                 leaders: true
             },
         });
-        return activities;
+        return activities as ActivityDto[];
     }
 
 

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -1,6 +1,6 @@
 import { prisma } from "./prisma.js";
 import { startAndEndOfWeek } from "../utils/weekCalculator.js";
-import { ActivityTemplate, Profile } from "../generated/prisma/index.js";
+import { Profile } from "../generated/prisma/index.js";
 import { ScheduleDto, ActivityDto } from '../types/index.js';
 import { formatSchedule } from "./utils.js";
 export class READ {
@@ -142,9 +142,13 @@ export class READ {
     // all activities updated after a given timestamp
     // static async activitiesUpdatedAfter(lastRequest: Date){}
 
-    static async activityById(activityId: string): Promise<ActivityTemplate | null> {
+    static async activityById(activityId: string) {
         const activity = await prisma.activityTemplate.findUnique({
-            where: { id: activityId }
+            where: { id: activityId },
+            include: {
+                timeSlots: true,
+                leaders: true
+            }
         });
         return activity;
     }

--- a/server/src/routes/activities.routes.ts
+++ b/server/src/routes/activities.routes.ts
@@ -44,8 +44,8 @@ router.get(
 // GET /activities
 router.get('', getActivities);
 
-// GET /activities/:activityId --- anyone logged in --> get single activity details
-router.get('/:activityId', authMiddleware, getActivityById);
+// GET /activities/:activityId --- public --> get single activity details
+router.get('/:activityId', getActivityById);
 
 // POST /activities --- leader only --> create new activity
 router.post(

--- a/server/src/routes/activities.routes.ts
+++ b/server/src/routes/activities.routes.ts
@@ -7,7 +7,8 @@ import {
   deleteActivity,
   registerParticipation,
   unregisterParticipation,
-  getActivityParticipants
+  getActivityParticipants,
+  getActivityById
 } from '../controllers/activities.controller.js';
 import { authMiddleware, restrictToMinRole } from '../middleware/auth.js';
 import { ProfileRole } from '../db/prisma.js';
@@ -32,8 +33,19 @@ router.patch(
   updateScheduleStatusHandler,
 );
 
+// GET /activities/:activityId/participants --- leader only --> get registered participants
+router.get(
+  '/:activityId/participants',
+  authMiddleware,
+  restrictToMinRole(ProfileRole.LEADER),
+  getActivityParticipants
+);
+
 // GET /activities
 router.get('', getActivities);
+
+// GET /activities/:activityId --- anyone logged in --> get single activity details
+router.get('/:activityId', authMiddleware, getActivityById);
 
 // POST /activities --- leader only --> create new activity
 router.post(
@@ -59,13 +71,6 @@ router.delete(
   deleteActivity
 );
 
-// GET /activities/:activityId/participants --- leader only --> get registered participants
-router.get(
-  '/:activityId/participants',
-  authMiddleware,
-  restrictToMinRole(ProfileRole.LEADER),
-  getActivityParticipants
-);
 
 
 router.post(

--- a/server/src/routes/activities.routes.ts
+++ b/server/src/routes/activities.routes.ts
@@ -6,7 +6,8 @@ import {
   updateActivity,
   deleteActivity,
   registerParticipation,
-  unregisterParticipation
+  unregisterParticipation,
+  getActivityParticipants
 } from '../controllers/activities.controller.js';
 import { authMiddleware, restrictToMinRole } from '../middleware/auth.js';
 import { ProfileRole } from '../db/prisma.js';
@@ -57,6 +58,15 @@ router.delete(
   restrictToMinRole(ProfileRole.LEADER),
   deleteActivity
 );
+
+// GET /activities/:activityId/participants --- leader only --> get registered participants
+router.get(
+  '/:activityId/participants',
+  authMiddleware,
+  restrictToMinRole(ProfileRole.LEADER),
+  getActivityParticipants
+);
+
 
 router.post(
   '/:activityId/schedules/:scheduleId/participate',

--- a/server/src/types/activity.types.ts
+++ b/server/src/types/activity.types.ts
@@ -45,3 +45,22 @@ export interface UpdateScheduleStatusDto {
   status: ActivityStatus;
   message: string;
 }
+
+export interface ParticipantScheduleDto {
+  scheduleId: string;
+  startAt: Date;
+  endAt: Date | null;
+  status: ActivityStatus;
+  participants: {
+    id: string;
+    profileName: string | null;
+    email: string;
+  }[];
+}
+
+export interface ActivityParticipantsDto {
+  activityId: string;
+  activityName: string;
+  schedules: ParticipantScheduleDto[];
+}
+

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -37,6 +37,8 @@ export type {
   Activity,
   TimeSlot,
   ActivityDto,
+  ParticipantScheduleDto,
+  ActivityParticipantsDto,
 } from './activity.types.js';
 
 export type { ScheduleDto } from './schedule.types.js';


### PR DESCRIPTION
Closes #26

Added a leader attendee list view on the activity detail page. Leaders, board members, and admins can see a list of registered participants grouped by schedule for each activity.

Backend
GET /api/activities/:activityId - new endpoint to fetch a single activity by id (open to authenticated users)
GET /api/activities/:activityId/participants - new endpoint returning all schedules for an activity with their registered participants, restricted to LEADER and above. Leaders must own the activity, BOARD_MEMBER/ADMIN bypass the ownership check.

Frontend
New ActivityDetailPage.jsx — shows activity details (name, description, location, capacity, time slots) and an attendee list section for leaders
ActivitiesPage.jsx - activity names now link to the detail page
SchedulePage.jsx - activity card titles now link to the detail page
App.jsx - replaced placeholder with ActivityDetailPage

How to test
Log in as a leader (e.g. user2@example.com / user2pass)
Navigate to an activity they lead
Verify activity details are shown
Verify attendee list is visible grouped by schedule
Log in as a member and verify attendee list is not shown