### PR TITLE
Fix: API calls failing in production (frontend couldn't reach backend)

### DIFF
--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -193,8 +193,9 @@ export function AuthProvider({ children }) {
   // ── getAuthHeader ─────────────────────────────────────────
   // Returns the Authorization header needed for protected API calls.
   // Usage in any service file:
+  //   import { API_BASE_URL } from '../services/apiConfig.js'
   //   const { getAuthHeader } = useAuth()
-  //   fetch('/api/schedule', { headers: { ...getAuthHeader(), 'Content-Type': 'application/json' } })
+  //   fetch(`${API_BASE_URL}/api/schedule`, { headers: { ...getAuthHeader(), 'Content-Type': 'application/json' } })
   function getAuthHeader() {
     return token ? { Authorization: `Bearer ${token}` } : {}
     // authMiddleware checks: req.headers.authorization?.startsWith('Bearer ')

--- a/client/src/pages/ActivitiesPage.jsx
+++ b/client/src/pages/ActivitiesPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import { fetchFavorites, addFavorite, removeFavorite, } from '../services/FavoritesService.js'
+import { API_BASE_URL } from '../services/apiConfig.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
 
@@ -20,7 +21,7 @@ export default function ActivitiesPage() {
     async function fetchActivities() {
       try {
         const response = await fetch(
-          '/api/activities'
+          `${API_BASE_URL}/api/activities`
         )
 
         if (!response.ok) {

--- a/client/src/pages/ActivityFormPage.jsx
+++ b/client/src/pages/ActivityFormPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
+import { API_BASE_URL } from '../services/apiConfig.js'
 import { Button, Input, Card } from '../components/ui'
 
 const WEEKDAYS = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY']
@@ -31,7 +32,7 @@ export default function ActivityFormPage() {
   // Load existing activity in edit mode
   useEffect(() => {
     if (!isEditMode) return
-    fetch(`/api/activities/${activityId}`, {
+    fetch(`${API_BASE_URL}/api/activities/${activityId}`, {
       headers: { ...getAuthHeader() }
     })
       .then(res => res.json())
@@ -120,8 +121,8 @@ export default function ActivityFormPage() {
 
     try {
       const url = isEditMode
-        ? `/api/activities/${activityId}`
-        : '/api/activities'
+        ? `${API_BASE_URL}/api/activities/${activityId}`
+        : `${API_BASE_URL}/api/activities`
 
       const res = await fetch(url, {
         method: isEditMode ? 'PUT' : 'POST',

--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -4,6 +4,10 @@ import Button from '../components/ui/Button.jsx'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 
+// Central API base URL — prepends the backend origin in production
+// while staying empty in dev so the vite proxy keeps working.
+import { API_BASE_URL } from '../services/apiConfig.js'
+
 // ─────────────────────────────────────────────────────────────
 // SchedulePage
 //
@@ -113,7 +117,7 @@ useEffect(() => {
     try {
 
       const response = await fetch(
-        '/api/schedules/current'
+        `${API_BASE_URL}/api/schedules/current`
       )
 
       const {data} = await response.json()

--- a/client/src/services/AuthService.js
+++ b/client/src/services/AuthService.js
@@ -14,7 +14,12 @@
 // Never rely on the login/register response for name or email.
 // Never rely on localStorage for anything beyond token and {id, role}.
 
-const BASE = '/api/auth'
+import { API_BASE_URL } from './apiConfig.js'
+
+// Prefix every auth route with the backend origin.
+// In dev  API_BASE_URL is ''  → BASE === '/api/auth' → vite proxy handles it.
+// In prod API_BASE_URL is the deployed backend → BASE is the full URL.
+const BASE = `${API_BASE_URL}/api/auth`
 
 // ── loginRequest ──────────────────────────────────────────────
 // POST /api/auth/login
@@ -68,16 +73,12 @@ export async function registerRequest(email, password, name) {
 // GET /api/auth/me
 // Protected by authMiddleware — MUST send Bearer token.
 //
-// This is now the ONLY source of truth for the user's name and email.
-// The JWT payload only carries { id, role } so we cannot get
-// name/email from the token or from the login response directly.
-//
 // Called:
-//   1. After login/register — to get the full user object
+//   1. After login/register — to verify the session
 //   2. On page load — to rehydrate the session from a stored token
 //
-// Returns the full user object: { id, email, name, role }
-// Throws if the token is missing, expired, or the user no longer exists
+// Returns { id, role } — the live DB values via authMiddleware.
+// Throws if the token is missing, expired, or the user no longer exists.
 export async function getMeRequest(token) {
   const res = await fetch(`${BASE}/me`, {
     method:  'GET',
@@ -97,20 +98,8 @@ export async function getMeRequest(token) {
     throw new Error(json.error || 'Session expired. Please log in again.')
   }
 
-  // json.data = { user: { id, email, name, role } }
-  // getMeHandler in auth.controller.ts does:
-  //   res.json({ status: 'success', data: { user: req.user } })
-  // But req.user from authMiddleware is only { id, role } —
-  // the DB lookup in authMiddleware uses select: { id: true, role: true }
-  //
-  // WAIT: re-reading auth.controller.ts getMeHandler:
-  //   res.json({ status: 'success', data: { user: req.user } })
-  // and auth.middleware attaches: req.user = { id, role }
-  //
-  // So /me actually returns { id, role } not the full profile.
-  // The full profile (with name/email) comes from the login response.
-  // We use /me only for rehydration to verify the token is still valid
-  // and to get the current role (in case it changed since last login).
+  // json.data.user from auth.controller.ts getMeHandler.
+  // authMiddleware attaches req.user = { id, role } so /me returns those.
+  // Used to verify the token and refresh the live role.
   return json.data.user
-  // Returns { id, role } — the live DB values after middleware lookup
 }

--- a/client/src/services/FavoritesService.js
+++ b/client/src/services/FavoritesService.js
@@ -1,50 +1,60 @@
+// All API calls for the user's favorite activities live here.
+// ActivitiesPage imports these — nothing else should call them directly.
+ 
+import { API_BASE_URL } from './apiConfig.js'
+ 
+// All favorites routes are scoped under /api/users/me/favorites.
+// Defining BASE once keeps the calls below short and consistent
+// with the pattern in AuthService.js.
+const BASE = `${API_BASE_URL}/api/users/me/favorites`
+ 
+// ── fetchFavorites ────────────────────────────────────────────
+// GET /api/users/me/favorites
+// Returns the full JSON body: { status, data: [...activities] }
+// Protected — must send Bearer token.
 export async function fetchFavorites(token) {
-
-  const response = await fetch(
-    '/api/users/me/favorites',
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  )
-
+ 
+  const response = await fetch(BASE, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+ 
   if (!response.ok) {
     throw new Error('Failed to fetch favorites')
   }
-
+ 
   return response.json()
 }
-
+ 
+// ── addFavorite ───────────────────────────────────────────────
+// POST /api/users/me/favorites/:activityId
+// No response body needed — we just want to know it succeeded.
 export async function addFavorite(activityId, token) {
-
-  const response = await fetch(
-    `/api/users/me/favorites/${activityId}`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  )
-
+ 
+  const response = await fetch(`${BASE}/${activityId}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+ 
   if (!response.ok) {
     throw new Error('Failed to add favorite')
   }
 }
-
+ 
+// ── removeFavorite ────────────────────────────────────────────
+// DELETE /api/users/me/favorites/:activityId
 export async function removeFavorite(activityId, token) {
-
-  const response = await fetch(
-    `/api/users/me/favorites/${activityId}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  )
-
+ 
+  const response = await fetch(`${BASE}/${activityId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+ 
   if (!response.ok) {
     throw new Error('Failed to remove favorite')
   }

--- a/client/src/services/apiConfig.js
+++ b/client/src/services/apiConfig.js
@@ -1,0 +1,26 @@
+// Single source of truth for the backend base URL.
+//
+// Why this file exists:
+//   In dev, vite.config.js proxies '/api/*' to http://localhost:3001
+//   so relative URLs like fetch('/api/activities') just work.
+//   In production (Vercel) there is NO proxy — the frontend and
+//   backend are on different origins, so we must prefix every
+//   request with the deployed backend URL.
+//
+// Usage:
+//   import { API_BASE_URL } from '../services/apiConfig.js'
+//   fetch(`${API_BASE_URL}/api/activities`)
+//
+// How VITE_API_URL is set:
+//   - Local dev:   leave it unset → falls back to '' → vite proxy handles it
+//   - Production:  set VITE_API_URL in Vercel project settings to the
+//                  deployed backend origin, e.g. https://hkif-api.onrender.com
+//                  (NO trailing slash, NO '/api' suffix)
+//
+// Note: Vite inlines env vars at BUILD time, not runtime.
+// If you change VITE_API_URL on Vercel you must redeploy.
+// ─────────────────────────────────────────────────────────────
+
+export const API_BASE_URL = import.meta.env.VITE_API_URL ?? ''
+// '' (empty string) keeps relative paths working in dev, which means
+// the vite proxy in vite.config.js still kicks in and forwards to localhost:3001.


### PR DESCRIPTION
### Fix: API calls failing in production (frontend couldn't reach backend)

Centralized the backend base URL so the frontend talks to the deployed backend in production. Every `fetch('/api/...')` call now goes through `${API_BASE_URL}/api/...` where `API_BASE_URL` reads from `VITE_API_URL` at build time.

### What happened
All our fetch calls were relative (`/api/activities`, `/api/auth/login`, etc.). That works locally because of the vite proxy in `vite.config.js`, but the proxy only exists in `vite dev` — it doesn't get bundled. So on Vercel the requests were going to `vercel.app/api/...`, which doesn't exist, and nothing was loading.

### Changes
- New file: `client/src/services/apiConfig.js` — single source of truth for the base URL. Falls back to `''` when `VITE_API_URL` isn't set so local dev keeps working without any setup.
- Updated `AuthService.js`, `FavoritesService.js`, `SchedulePage.jsx`, `ActivitiesPage.jsx`, `ActivityFormPage.jsx` to use it.
- Updated the usage example in `AuthContext.jsx` comments so we don't copy the broken pattern next time.
- Added `client/.env.example` so it's clear what env var to set.

### Setup needed before this works in prod
`VITE_API_URL` has to be set in the Vercel project's env vars (pointing at the deployed backend), then redeployed. Vite inlines env vars at build time so a redeploy is required for changes to take effect.

Local dev needs no setup — just don't create a `client/.env` and the vite proxy handles everything.

### How to test
- **Locally**: `cd client && npm run dev`, backend running on `:3001`, log in / browse activities / schedule — should all work as before.
- **Prod**: after Vercel env var is set + redeploy, open the deployed URL and check the network tab — `/api/*` requests should hit the deployed backend, not the vercel.app domain.

### Notes for reviewers
- I kept the per-file `BASE` constants in `AuthService` and `FavoritesService` since they group related routes nicely — they just now derive from `API_BASE_URL`.
- One thing I noticed but didn't touch: the role check in `ActivityFormPage` runs *after* the `useEffect` that loads the activity, so unauthorized users still fire one fetch on mount. Not a security issue (backend rejects it), but might be worth a quick follow-up.