### PR TITLE
feat: add cancellation badge on activity cards and detail page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import LoginPage    from './pages/LoginPage.jsx'
 import RegisterPage from './pages/RegisterPage.jsx'
 import ActivityFormPage from './pages/ActivityFormPage.jsx'
 import SchedulePage from './pages/SchedulePage.jsx'
+import ActivityDetailPage from './pages/ActivityDetailPage.jsx'
 
 // ── ProtectedRoute ────────────────────────────────────────────
 // Wraps any route that requires login.
@@ -95,7 +96,7 @@ function AppRoutes() {
           <Route path="/register"       element={<RegisterPage />} />
           <Route path="/activities" element={<ActivitiesPage />} />
           <Route path="/activities/new" element={<ProtectedRoute><ActivityFormPage /></ProtectedRoute>} />
-          <Route path="/activities/:id" element={<Placeholder title="Activity Detail" />} />
+          <Route path="/activities/:id" element={<ActivityDetailPage />} />
           <Route path="/activities/:id/edit" element={<ProtectedRoute><ActivityFormPage /></ProtectedRoute>} />
 
           {/* Protected route — must be logged in */}

--- a/client/src/pages/ActivitiesPage.jsx
+++ b/client/src/pages/ActivitiesPage.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx'
 import { fetchFavorites, addFavorite, removeFavorite, } from '../services/FavoritesService.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
-import Badge from '../components/ui/Badge.jsx'
+import Badge, { STATUS_VARIANT } from '../components/ui/Badge.jsx'
 
 export default function ActivitiesPage() {
   // ── API State ─────────────────────────────────────────────
@@ -184,7 +184,7 @@ export default function ActivitiesPage() {
               <h2 style={{ marginBottom: '8px', display: 'flex', alignItems: 'center', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
                 {activity.name}
                 {activity.defaultStatus === 'CANCELLED' && (
-                  <Badge variant="danger">Cancelled</Badge>
+                  <Badge variant={STATUS_VARIANT[activity.defaultStatus]}>Cancelled</Badge>
                 )}
               </h2>
 

--- a/client/src/pages/ActivitiesPage.jsx
+++ b/client/src/pages/ActivitiesPage.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx'
 import { fetchFavorites, addFavorite, removeFavorite, } from '../services/FavoritesService.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
+import Badge from '../components/ui/Badge.jsx'
 
 export default function ActivitiesPage() {
   // ── API State ─────────────────────────────────────────────
@@ -180,8 +181,11 @@ export default function ActivitiesPage() {
                   ? '♥'
                   : '♡'}
               </button>
-              <h2 style={{ marginBottom: '8px' }}>
+              <h2 style={{ marginBottom: '8px', display: 'flex', alignItems: 'center', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
                 {activity.name}
+                {activity.defaultStatus === 'CANCELLED' && (
+                  <Badge variant="danger">Cancelled</Badge>
+                )}
               </h2>
 
               {/* Activity details */}
@@ -221,6 +225,17 @@ export default function ActivitiesPage() {
                   ))}
                 </div>
               )}
+
+              {/* View Details Button */}
+              <div style={{ marginTop: 'var(--space-4)', display: 'flex', gap: 'var(--space-3)' }}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigate(`/activities/${activity.id}`)}
+                >
+                  View Details
+                </Button>
+              </div>
             </Card>
           ))
         )}

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext.jsx'
+import Card from '../components/ui/Card.jsx'
+import Button from '../components/ui/Button.jsx'
+import Badge from '../components/ui/Badge.jsx'
+
+export default function ActivityDetailPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { isAuthenticated, user } = useAuth()
+  const [activity, setActivity] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    async function loadActivity() {
+      try {
+        const res = await fetch(`/api/activities/${id}`)
+        if (!res.ok) {
+          throw new Error('Failed to fetch activity')
+        }
+        const json = await res.json()
+        if (json.status === 'success' && json.data) {
+          setActivity(json.data)
+        } else {
+          setError('Activity not found')
+        }
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadActivity()
+  }, [id])
+
+  if (loading) {
+    return (
+      <div style={{ padding: 'var(--space-12) var(--space-6)', maxWidth: '800px', margin: '0 auto' }}>
+        <p>Loading activity details...</p>
+      </div>
+    )
+  }
+
+  if (error || !activity) {
+    return (
+      <div style={{ padding: 'var(--space-12) var(--space-6)', maxWidth: '800px', margin: '0 auto', textAlign: 'center' }}>
+        <h1 style={{ fontFamily: 'var(--font-serif)', fontSize: 'var(--text-3xl)', marginBottom: 'var(--space-4)' }}>
+          Error
+        </h1>
+        <p style={{ color: 'var(--color-danger)', marginBottom: 'var(--space-6)' }}>
+          {error || 'Activity not found'}
+        </p>
+        <Link to="/activities" style={{ color: 'var(--color-primary)', fontWeight: 600 }}>
+          ← Back to Activities
+        </Link>
+      </div>
+    )
+  }
+
+  const isCancelled = activity.defaultStatus === 'CANCELLED'
+  const canEdit = ['BOARD_MEMBER', 'ADMIN'].includes(user?.role)
+
+  return (
+    <div className="page-wrapper" style={{ background: 'var(--color-surface)', minHeight: 'calc(100vh - var(--nav-height))' }}>
+      <div className="container" style={{ maxWidth: '800px' }}>
+        
+        {/* Navigation & Actions Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--space-6)' }}>
+          <Link to="/activities" style={{ color: 'var(--color-primary-dark)', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 'var(--space-1)' }}>
+            ← Back to Activities
+          </Link>
+          {canEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(`/activities/${activity.id}/edit`)}
+            >
+              Edit Activity
+            </Button>
+          )}
+        </div>
+
+        {/* Cancelled Banner */}
+        {isCancelled && (
+          <div style={{
+            background: 'var(--color-danger-light)',
+            borderLeft: '6px solid var(--color-danger)',
+            color: 'var(--color-danger)',
+            padding: 'var(--space-4) var(--space-6)',
+            borderRadius: 'var(--radius-md)',
+            marginBottom: 'var(--space-6)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-3)',
+            fontWeight: 700,
+            fontSize: 'var(--text-base)',
+            boxShadow: 'var(--shadow-sm)',
+          }}>
+            <span style={{ fontSize: 'var(--text-xl)' }}>⚠️</span>
+            <div>
+              <p style={{ margin: 0, fontWeight: 700 }}>This activity has been cancelled.</p>
+              <p style={{ margin: '2px 0 0', fontWeight: 400, fontSize: 'var(--text-sm)', opacity: 0.9 }}>
+                No active schedules or future sessions will run until the activity is reactivated.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Main Details Card */}
+        <Card padding="lg" shadow="md">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 'var(--space-4)', marginBottom: 'var(--space-4)' }}>
+            <div>
+              <h1 style={{
+                fontFamily: 'var(--font-serif)',
+                fontSize: 'var(--text-3xl)',
+                fontWeight: 700,
+                color: 'var(--color-text)',
+                margin: 0
+              }}>
+                {activity.name}
+              </h1>
+              <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', marginTop: 'var(--space-1)' }}>
+                Activity Details
+              </p>
+            </div>
+            
+            {/* Status Badge */}
+            <Badge variant={isCancelled ? 'danger' : 'success'}>
+              {isCancelled ? 'Cancelled' : 'Active'}
+            </Badge>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', marginTop: 'var(--space-6)' }}>
+            
+            {/* Location */}
+            <div style={{ borderBottom: '1px solid var(--color-border)', paddingBottom: 'var(--space-3)' }}>
+              <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: '2px' }}>
+                Location
+              </p>
+              <p style={{ fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--color-text)' }}>
+                📍 {activity.location}
+              </p>
+            </div>
+
+            {/* Capacity */}
+            <div style={{ borderBottom: '1px solid var(--color-border)', paddingBottom: 'var(--space-3)' }}>
+              <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: '2px' }}>
+                Capacity Limits
+              </p>
+              <p style={{ fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--color-text)' }}>
+                👥 {activity.maxCapacity ? `${activity.maxCapacity} people max` : 'Unlimited capacity'}
+              </p>
+            </div>
+
+            {/* Description */}
+            {activity.description && (
+              <div style={{ borderBottom: '1px solid var(--color-border)', paddingBottom: 'var(--space-3)' }}>
+                <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: '2px' }}>
+                  Description
+                </p>
+                <p style={{ fontSize: 'var(--text-base)', color: 'var(--color-text)', lineHeight: 1.6 }}>
+                  {activity.description}
+                </p>
+              </div>
+            )}
+
+            {/* Notes */}
+            {activity.notes && (
+              <div style={{ borderBottom: '1px solid var(--color-border)', paddingBottom: 'var(--space-3)' }}>
+                <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: '2px' }}>
+                  Important Notes
+                </p>
+                <p style={{ fontSize: 'var(--text-base)', color: 'var(--color-text)', fontStyle: 'italic' }}>
+                  📝 {activity.notes}
+                </p>
+              </div>
+            )}
+
+            {/* Time Slots */}
+            {activity.timeSlots?.length > 0 && (
+              <div>
+                <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: 'var(--space-2)' }}>
+                  Weekly Time Slots
+                </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                  {activity.timeSlots.map(slot => (
+                    <div
+                      key={slot.id}
+                      style={{
+                        background: 'var(--color-surface)',
+                        padding: 'var(--space-2) var(--space-3)',
+                        borderRadius: 'var(--radius-sm)',
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center'
+                      }}
+                    >
+                      <span style={{ fontWeight: 600 }}>{slot.weekday}</span>
+                      <span style={{ color: 'var(--color-text-muted)' }}>
+                        {new Date(slot.startTime).toISOString().slice(11, 16)} - {new Date(slot.endTime).toISOString().slice(11, 16)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
-import Badge from '../components/ui/Badge.jsx'
+import Badge, { STATUS_VARIANT } from '../components/ui/Badge.jsx'
 
 export default function ActivityDetailPage() {
   const { id } = useParams()
@@ -127,8 +127,8 @@ export default function ActivityDetailPage() {
             </div>
             
             {/* Status Badge */}
-            <Badge variant={isCancelled ? 'danger' : 'success'}>
-              {isCancelled ? 'Cancelled' : 'Active'}
+            <Badge variant={STATUS_VARIANT[activity.defaultStatus]}>
+              {activity.defaultStatus}
             </Badge>
           </div>
 


### PR DESCRIPTION
Closes #28

Added cancellation indicators across the app so users can clearly see when an activity has been cancelled.
Changes

ActivitiesPage.jsx - added a red "Cancelled" badge next to the activity name when defaultStatus === 'CANCELLED'
ActivityDetailPage.jsx - added a prominent warning banner at the top of the detail page when the activity is cancelled, plus a status badge next to the activity title

No backend changes needed - defaultStatus with CANCELLED value already exists in the database.
How to test

Set an activity's defaultStatus to CANCELLED in the database
Go to /activities and verify the red Cancelled badge appears on the card
Click into the activity and verify the warning banner appears at the top of the detail page
Set the status back to ACTIVE and verify both indicators disappear