### PR TITLE
Bug participant count

### DIFF
--- a/client/src/pages/ActivityDetailPage.jsx
+++ b/client/src/pages/ActivityDetailPage.jsx
@@ -144,6 +144,19 @@ export default function ActivityDetailPage() {
               </p>
             </div>
 
+            {/*
+              TODO (bug ticket: "spots left counter not updating"):
+              Add register / unregister UI here once this page wires
+              up to a specific schedule. The same pattern used in
+              SchedulePage applies — call ParticipationService and
+              read participantCount from the response to refresh the
+              "spots left" display + disable the button when full.
+              This page currently only renders the activity template
+              (no scheduled session), so there's no participation UI
+              to bug-fix yet. Tracked separately from the schedule
+              fix shipped in this PR.
+            */}
+
             {/* Capacity */}
             <div style={{ borderBottom: '1px solid var(--color-border)', paddingBottom: 'var(--space-3)' }}>
               <p style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.05em', marginBottom: '2px' }}>

--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -5,6 +5,10 @@ import ScheduleFilters from '../components/ScheduleFilters.jsx'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import { fetchFavorites } from '../services/FavoritesService.js'
+import {
+  registerParticipation,
+  unregisterParticipation,
+} from '../services/ParticipationService.js'
 
 // Central API base URL — prepends the backend origin in production
 // while staying empty in dev so the vite proxy keeps working.
@@ -198,8 +202,23 @@ export default function SchedulePage() {
             location:
               singleSchedule.activity?.location || 'Unknown',
 
-            availableSpots:
-              singleSchedule.activity?.maxCapacity || 0,
+            // Max capacity from the activity template + the number
+            // of currently registered participants. We compute
+            // "spots left" at render time as the difference between
+            // these two. Both fields drive the disable-when-full
+            // logic on the Attend button.
+            //
+            // NOTE: the /api/schedules/current endpoint doesn't
+            // include participantCount yet, so we default it to 0
+            // on initial load. The count updates correctly the
+            // moment the user clicks Attend / Leave (the response
+            // from /participate returns the authoritative count).
+            // Backend ticket needed to include participantCount in
+            // the schedule list response for accurate first paint.
+            maxCapacity:
+              singleSchedule.activity?.maxCapacity ?? null,
+            participantCount:
+              singleSchedule.participantCount ?? 0,
 
             cancelled:
               singleSchedule.status === 'CANCELLED',
@@ -394,12 +413,96 @@ export default function SchedulePage() {
     )
   }
 
-  // ── Filter handlers ──────────────────────────────────────
+// ── Filter handlers ──────────────────────────────────────
   function handleClearFilters() {
     setFilterSport('ALL')
     setFilterDay('ALL')
     setFilterFavoritesOnly(false)
   }
+
+  // ── Toggle Attendance ────────────────────────────────────
+  // Wires the Attend / Leave button on each card to the backend.
+  // Pattern mirrors ActivitiesPage.handleToggleFavorite:
+  //   1. Optimistically update local state (snappy UI)
+  //   2. Call the API
+  //   3. On success, overwrite participantCount with the server's
+  //      authoritative value — THIS is the actual bug fix; the
+  //      counter previously never moved after register/unregister
+  //   4. On failure, roll back both attendance + count
+  async function handleToggleAttendance(activity) {
+
+    // Logged-out users get redirected before any state changes
+    if (!isAuthenticated) {
+      navigate('/login')
+      return
+    }
+
+    // Real backend entries carry activity.activityId. Without it
+    // we can't hit /participate, so the mock-data dev path stays
+    // a pure local toggle. Once the backend is fully seeded and
+    // the schedule API is hooked up, this guard never triggers.
+    if (!activity.activityId) {
+      setAttendingActivities(prev =>
+        prev.includes(activity.id)
+          ? prev.filter(id => id !== activity.id)
+          : [...prev, activity.id]
+      )
+      return
+    }
+
+    const isCurrentlyAttending = attendingActivities.includes(activity.id)
+
+    // Snapshots so we can roll back if the request fails
+    const previousAttending = attendingActivities
+    const previousCount    = activity.participantCount
+
+    // ── Optimistic update ────────────────────────────────
+    // Toggle attendance and nudge the count by ±1 so the card
+    // reacts instantly. The server's response will reconcile
+    // any drift a moment later.
+    if (isCurrentlyAttending) {
+      setAttendingActivities(prev => prev.filter(id => id !== activity.id))
+      setActivities(prev => prev.map(a =>
+        a.id === activity.id
+          ? { ...a, participantCount: Math.max(0, (a.participantCount ?? 0) - 1) }
+          : a
+      ))
+    } else {
+      setAttendingActivities(prev => [...prev, activity.id])
+      setActivities(prev => prev.map(a =>
+        a.id === activity.id
+          ? { ...a, participantCount: (a.participantCount ?? 0) + 1 }
+          : a
+      ))
+    }
+
+    // ── API call + reconcile ─────────────────────────────
+    try {
+      const apiResponse = isCurrentlyAttending
+        ? await unregisterParticipation(activity.activityId, activity.id, token)
+        : await registerParticipation(activity.activityId, activity.id, token)
+
+      // Server count is authoritative. Overwriting it here is the
+      // line that closes the bug ticket — the response shape is
+      // { status, data: { participantCount } }.
+      const serverCount = apiResponse?.data?.participantCount
+      if (typeof serverCount === 'number') {
+        setActivities(prev => prev.map(a =>
+          a.id === activity.id
+            ? { ...a, participantCount: serverCount }
+            : a
+        ))
+      }
+    } catch (error) {
+      console.error('Failed to update participation:', error)
+      // Roll everything back to the pre-click snapshot
+      setAttendingActivities(previousAttending)
+      setActivities(prev => prev.map(a =>
+        a.id === activity.id ? { ...a, participantCount: previousCount } : a
+      ))
+    }
+  }
+
 
   if (loading) {
     return (
@@ -607,7 +710,29 @@ export default function SchedulePage() {
                     </p>
                   )}
 
-                  {dayActivities.map(activity => (
+                  {dayActivities.map(activity => {
+                  // ── Per-card derived state ────────────────
+                    // Computed once per render of this card so
+                    // the spots counter and the button can share
+                    // the same source of truth.
+                    const isAttending = attendingActivities.includes(activity.id)
+
+                    // Real backend cards have maxCapacity + participantCount.
+                    // Mock cards still use the legacy availableSpots field,
+                    // so we keep a fallback to avoid breaking the dev preview.
+                    const hasCapacityData = (
+                      typeof activity.maxCapacity      === 'number' &&
+                      typeof activity.participantCount === 'number'
+                    )
+
+                    const spotsLeft = hasCapacityData
+                      ? Math.max(0, activity.maxCapacity - activity.participantCount)
+                      : activity.availableSpots
+
+                    const isFull = hasCapacityData
+                      && activity.participantCount >= activity.maxCapacity
+
+                    return (
 
                     <div
                       key={activity.id}
@@ -674,7 +799,7 @@ export default function SchedulePage() {
 
                       {/* Spots */}
                       <p style={{ fontSize: '0.85rem' }}>
-                        {activity.availableSpots} spots left
+                        {spotsLeft} spots left
                       </p>
 
                       {/* Notes */}
@@ -694,41 +819,23 @@ export default function SchedulePage() {
                       {!activity.cancelled && (
                         <Button
                           size="sm"
-                          variant={
-                            attendingActivities.includes(activity.id)
-                              ? 'ghost'
-                              : 'primary'
-                          }
+                          variant={isAttending ? 'ghost' : 'primary'}
+                          // Disable when the schedule is full AND the
+                          // user isn't already attending. Attendees
+                          // can still leave a full session.
+                          disabled={!isAttending && isFull}
                           style={{ marginTop: '8px' }}
-                          onClick={() => {
-
-                            // Redirect logged-out users
-                            if (!isAuthenticated) {
-                              navigate('/login')
-                              return
-                            }
-
-                            // Toggle attendance
-                            if (attendingActivities.includes(activity.id)) {
-                              setAttendingActivities(
-                                attendingActivities.filter(id => id !== activity.id)
-                              )
-                            } else {
-                              setAttendingActivities([
-                                ...attendingActivities,
-                                activity.id,
-                              ])
-                            }
-                          }}
+                          onClick={() => handleToggleAttendance(activity)}
                         >
-                          {attendingActivities.includes(activity.id)
+                          {isAttending
                             ? 'Leave'
-                            : 'Attend'}
+                            : (isFull ? 'Full' : 'Attend')}
                         </Button>
                       )}
 
                     </div>
-                  ))}
+                    )
+          })}
 
                 </div>
               </div>

--- a/client/src/services/ParticipationService.js
+++ b/client/src/services/ParticipationService.js
@@ -1,0 +1,82 @@
+// All API calls for registering / unregistering a user
+// from a specific schedule live here.
+//
+// SchedulePage imports these — nothing else should call them directly.
+// Pattern mirrors FavoritesService.js so the codebase stays consistent.
+
+import { API_BASE_URL } from './apiConfig.js'
+
+// The participate endpoints are scoped under
+// /api/activities/:activityId/schedules/:scheduleId/participate
+//
+// We build the path inside each function rather than a single BASE
+// constant because both IDs are dynamic per call.
+
+// ── registerParticipation ─────────────────────────────────────
+// POST /api/activities/:activityId/schedules/:scheduleId/participate
+//
+// Backend returns: { status: 'success', data: { participantCount: number } }
+// We return the full JSON body so the caller can read participantCount
+// and update its local "spots left" counter accordingly.
+//
+// Protected — must send Bearer token.
+export async function registerParticipation(activityId, scheduleId, token) {
+
+  const response = await fetch(
+    `${API_BASE_URL}/api/activities/${activityId}/schedules/${scheduleId}/participate`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  )
+
+  if (!response.ok) {
+    // Surface the backend message when possible so the UI can show
+    // something more useful than a generic error. The backend uses
+    // ApiError which serialises to { status: 'error', message: '...' }.
+    let message = 'Failed to register for this session'
+    try {
+      const body = await response.json()
+      if (body?.message) message = body.message
+    } catch {
+      // Body wasn't JSON — fall back to the default message.
+    }
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+// ── unregisterParticipation ───────────────────────────────────
+// DELETE /api/activities/:activityId/schedules/:scheduleId/participate
+//
+// Backend returns: { status: 'success', data: { participantCount: number } }
+// Same shape as register — the caller uses participantCount to refresh
+// the "spots left" display.
+export async function unregisterParticipation(activityId, scheduleId, token) {
+
+  const response = await fetch(
+    `${API_BASE_URL}/api/activities/${activityId}/schedules/${scheduleId}/participate`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  )
+
+  if (!response.ok) {
+    let message = 'Failed to unregister from this session'
+    try {
+      const body = await response.json()
+      if (body?.message) message = body.message
+    } catch {
+      // Non-JSON response — keep the default.
+    }
+    throw new Error(message)
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## What
Fixes the bug where the "spots left" counter on schedule cards didn't move when a user registered or unregistered from a session.

The backend was already returning the updated `participantCount` in both `/participate` responses — the client just wasn't using it. Now it does.

## Changes
- New `client/src/services/ParticipationService.js` with `registerParticipation` and `unregisterParticipation`, following the same pattern as `FavoritesService.js`
- `SchedulePage.jsx`:
  - Activity shape now carries `maxCapacity` + `participantCount` instead of the misleading `availableSpots: maxCapacity`
  - The Attend/Leave button now actually hits the backend (it was a local-only toggle before)
  - Optimistic update with rollback on failure, same pattern as `handleToggleFavorite` in `ActivitiesPage`
  - Server's `participantCount` from the response overwrites the optimistic value, so the counter reflects the real count
  - Register button is disabled and shows "Full" when `participantCount >= maxCapacity`
- `ActivityDetailPage.jsx`: added a TODO comment for future register UI work. No functional change — this page doesn't have a register button yet, so there's nothing to bug-fix on it. Filed as a note for whoever picks up the next ticket.

## What to look for when testing
- Log in as a MEMBER, find a schedule card, click Attend → spots-left should drop by 1
- Click Leave → spots-left should go back up
- Open DevTools → Network tab → the response from `/participate` should match what's shown on the card
- If you can seed a schedule at full capacity, the button should show "Full" and be disabled. A user already attending should still be able to Leave.
- Mock-data mode (when backend is offline / no real schedules) should still work as a local toggle — no console errors and the button still flips between Attend/Leave

## Known limitation (follow-up ticket)
The very first paint of the page shows `maxCapacity` as the spots-left number, because `/api/schedules/current` doesn't return `participantCount` per schedule yet. It corrects itself the moment any user interacts with a card. I'll open a small backend follow-up ticket so the initial render is also accurate.

## Scope
Closes the SchedulePage part of the bug ticket. ActivityDetailPage is tracked separately via the TODO comment since adding a register flow there is more of a feature than a bugfix.