### PR TITLE
feat(server): implement profiles by role endpoint for leader selection

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,7 +6,8 @@ import { errorHandler } from './middleware/errorHandler.js';
 import authRoutes from './routes/auth.routes.js';
 import activityRoutes from './routes/activities.routes.js';
 import scheduleRoutes from "./routes/schedule.routes.js";
-import userRoutes from './routes/user.routes.js'
+import userRoutes from './routes/user.routes.js';
+import profilesRoutes from './routes/profiles.routes.js';
 
 export const app = express();
 
@@ -24,6 +25,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/activities', activityRoutes);
 app.use('/api/schedules', scheduleRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/profiles', profilesRoutes);
 
 // 404 catch-all (must be last route)
 app.use((_req, res) => {

--- a/server/src/controllers/profiles.controller.ts
+++ b/server/src/controllers/profiles.controller.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler.js';
+import { READ } from '../db/queries.js';
+import { GetProfilesQuerySchema, parseZodError } from '../validators/index.js';
+import { ApiResponse, ProfileSummaryDto } from '../types/index.js';
+import { ZodError } from 'zod';
+import { ApiError } from '../utils/ApiError.js';
+
+const getProfiles = asyncHandler(
+  async (req: Request, res: Response<ApiResponse<ProfileSummaryDto[]>>) => {
+    let queryParams;
+    try {
+      queryParams = GetProfilesQuerySchema.parse(req.query);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw ApiError.badRequest(JSON.stringify(parseZodError(error)));
+      } else {
+        throw ApiError.internal(`Something went wrong: ${error}`);
+      }
+    }
+
+    const profiles = await READ.profilesByRole(queryParams.role);
+    res.status(200).json({ status: 'success', data: profiles });
+  }
+);
+
+export const controller = {
+  getProfiles,
+};

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -1,7 +1,7 @@
-import { prisma } from "./prisma.js";
+import { prisma, ProfileRole } from "./prisma.js";
 import { startAndEndOfWeek } from "../utils/weekCalculator.js";
 import { Profile } from "../generated/prisma/index.js";
-import { ScheduleDto, ActivityDto, ProfileDto } from '../types/index.js';
+import { ScheduleDto, ActivityDto, ProfileDto, ProfileSummaryDto } from '../types/index.js';
 import { ApiError } from "../utils/ApiError.js";
 import { formatSchedule } from "./utils.js";
 export class READ {
@@ -355,5 +355,20 @@ export class READ {
         });
     }
 
+    static async profilesByRole(role?: ProfileRole): Promise<ProfileSummaryDto[]> {
+        const where = role ? { role } : {};
+        return await prisma.profile.findMany({
+            where,
+            select: {
+                id: true,
+                profileName: true,
+                email: true,
+                role: true,
+            },
+            orderBy: {
+                profileName: 'asc'
+            }
+        });
+    }
 
 }

--- a/server/src/routes/profiles.routes.ts
+++ b/server/src/routes/profiles.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { controller as profilesController } from '../controllers/profiles.controller.js';
+import { authMiddleware, restrictToMinRole } from '../middleware/auth.js';
+import { ProfileRole } from '../db/prisma.js';
+
+const profilesRoutes = Router();
+
+// For every route: check if the user is logged in and has at least LEADER role
+profilesRoutes.use(authMiddleware);
+profilesRoutes.use(restrictToMinRole(ProfileRole.LEADER));
+
+profilesRoutes.get('/', profilesController.getProfiles);
+
+export default profilesRoutes;

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -57,7 +57,8 @@ export type {
 } from './favorites.types.js';
 
 export type {
-  ProfileDto
+  ProfileDto,
+  ProfileSummaryDto,
 } from './profile.types.js'
 
 export type {

--- a/server/src/types/profile.types.ts
+++ b/server/src/types/profile.types.ts
@@ -6,3 +6,6 @@ export type ProfileDto = Pick<Profile, 'profileName' | 'email' | 'role'> & {
     favorites: ActivityDto[],
     participations: ScheduleDto[]
 }
+
+export type ProfileSummaryDto = Pick<Profile, 'id' | 'profileName' | 'email' | 'role'>;
+

--- a/server/src/validators/index.ts
+++ b/server/src/validators/index.ts
@@ -33,3 +33,7 @@ export {
   UpdateScheduleSchema,
   ScheduleIdParamSchema,
 } from './schedule.validator.js'
+
+export {
+  GetProfilesQuerySchema,
+} from './profiles.validator.js';

--- a/server/src/validators/profiles.validator.ts
+++ b/server/src/validators/profiles.validator.ts
@@ -1,0 +1,6 @@
+import * as z from 'zod';
+import { ProfileRole } from '../db/prisma.js';
+
+export const GetProfilesQuerySchema = z.object({
+  role: z.nativeEnum(ProfileRole).optional(),
+});


### PR DESCRIPTION
## Overview
This PR implements the GET /api/profiles endpoint, providing the ability to fetch profiles filtered by role (primarily to support Isabelle's leader selection dropdown in the activity form).


## Routing & Security:
Restricts endpoint access using `authMiddleware` and `restrictToMinRole(ProfileRole.LEADER)` (access is limited to LEADER, BOARD_MEMBER, and ADMIN users).
Mounted the routes file at `/api/profiles` in `app.ts`.

## Verification & Testing
Local integration tests were executed successfully, verifying:

Role Guards: Regular MEMBER accounts correctly receive a 403 Forbidden error.
Authorized Access: Users with role LEADER and above successfully fetch profile lists.
Role Filtering: Requests like `GET /api/profiles?role=LEADER` return only profiles with the role LEADER.
Payload Privacy: Confirmed that password fields are absent from the returned list of users.
Query Validation: Requests with invalid roles correctly return a 400 Bad Request.