### PR TITLE
feat(server): automated weekly schedule generation with cron

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "17.4.2",
         "express": "5.2.1",
         "jsonwebtoken": "9.0.3",
+        "node-cron": "^4.2.1",
         "pg": "8.20.0",
         "zod": "^4.4.3"
       },
@@ -24,6 +25,7 @@
         "@types/express": "5.0.6",
         "@types/jsonwebtoken": "9.0.10",
         "@types/node": "25.6.0",
+        "@types/node-cron": "^3.0.11",
         "@types/pg": "8.20.0",
         "nodemon": "3.1.14",
         "prisma": "7.8.0",
@@ -50,7 +52,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -1059,9 +1062,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.20.0",
@@ -1528,8 +1539,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2125,6 +2135,7 @@
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2512,6 +2523,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
@@ -2648,6 +2668,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2817,6 +2838,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.8.0",
         "@prisma/dev": "0.24.3",
@@ -3075,8 +3097,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3432,6 +3453,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "jsonwebtoken": "9.0.3",
+    "node-cron": "^4.2.1",
     "pg": "8.20.0",
     "zod": "^4.4.3"
   },
@@ -30,6 +31,7 @@
     "@types/express": "5.0.6",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.6.0",
+    "@types/node-cron": "^3.0.11",
     "@types/pg": "8.20.0",
     "nodemon": "3.1.14",
     "prisma": "7.8.0",

--- a/server/src/cron/index.ts
+++ b/server/src/cron/index.ts
@@ -1,6 +1,6 @@
 // server/src/cron/index.ts
 //
-// Sets up the cron job that generates schedules every Monday at 00:01.
+// Sets up the cron job that generates schedules every Monday at 00:05.
 // Also runs once on startup as a fallback in case the server was down
 // on Monday morning.
 
@@ -9,9 +9,9 @@ import { generateWeeklySchedules } from './scheduleGenerator.js';
 
 export function initCronJobs(): void {
     // Weekly schedule generation
-    // Runs every Monday at 00:01 server time.
-    // '1 0 * * 1' = minute 1, hour 0, any day of month, any month, Monday (1)
-    cron.schedule('1 0 * * 1', async () => {
+    // Runs every Monday at 00:05 server time.
+    // '5 0 * * 1' = minute 5, hour 0, any day of month, any month, Monday (1)
+    cron.schedule('5 0 * * 1', async () => {
         console.log('[cron] Running weekly schedule generation...');
         try {
             await generateWeeklySchedules();
@@ -29,5 +29,5 @@ export function initCronJobs(): void {
         console.error('[cron] Startup schedule check failed:', err);
     });
 
-    console.log('[cron] Weekly schedule generation cron job registered (Monday 00:01).');
+    console.log('[cron] Weekly schedule generation cron job registered (Monday 00:05).');
 }

--- a/server/src/cron/index.ts
+++ b/server/src/cron/index.ts
@@ -1,0 +1,33 @@
+// server/src/cron/index.ts
+//
+// Sets up the cron job that generates schedules every Monday at 00:01.
+// Also runs once on startup as a fallback in case the server was down
+// on Monday morning.
+
+import cron from 'node-cron';
+import { generateWeeklySchedules } from './scheduleGenerator.js';
+
+export function initCronJobs(): void {
+    // Weekly schedule generation
+    // Runs every Monday at 00:01 server time.
+    // '1 0 * * 1' = minute 1, hour 0, any day of month, any month, Monday (1)
+    cron.schedule('1 0 * * 1', async () => {
+        console.log('[cron] Running weekly schedule generation...');
+        try {
+            await generateWeeklySchedules();
+        } catch (err) {
+            console.error('[cron] Schedule generation failed:', err);
+        }
+    });
+
+    // Startup fallback
+    // Runs once when the server starts. Safe to call anytime —
+    // generateWeeklySchedules() checks for existing schedules
+    // before creating new ones, so no duplicates are possible.
+    console.log('[cron] Running startup schedule check...');
+    generateWeeklySchedules().catch(err => {
+        console.error('[cron] Startup schedule check failed:', err);
+    });
+
+    console.log('[cron] Weekly schedule generation cron job registered (Monday 00:01).');
+}

--- a/server/src/cron/scheduleGenerator.ts
+++ b/server/src/cron/scheduleGenerator.ts
@@ -83,7 +83,7 @@ export async function generateWeeklySchedules(): Promise<void> {
             const existing = await prisma.schedule.findFirst({
                 where: {
                     activityId: activity.id,
-                    startAt: { gte: startDay, lte: endDay },
+                    startAt,
                 },
             });
 

--- a/server/src/cron/scheduleGenerator.ts
+++ b/server/src/cron/scheduleGenerator.ts
@@ -1,0 +1,110 @@
+// server/src/cron/scheduleGenerator.ts
+//
+// Core logic for generating Schedule rows for the coming week.
+// Called by the cron job every Monday at 00:01, and once on
+// server startup as a fallback (in case the server was down on Monday).
+
+import { prisma, ActivityStatus } from '../db/prisma.js';
+import { nextWeek, startAndEndOfWeek } from '../utils/weekCalculator.js';
+
+// weekdayMap 
+// Maps our Weekday enum to JS Date.getDay() values (0 = Sunday)
+const weekdayMap: Record<string, number> = {
+    MONDAY: 1,
+    TUESDAY: 2,
+    WEDNESDAY: 3,
+    THURSDAY: 4,
+    FRIDAY: 5,
+    SATURDAY: 6,
+    SUNDAY: 0,
+};
+
+// nextDateForWeekday
+// Given a base date and a weekday, returns the next occurrence
+// of that weekday on or after the base date.
+// Reuses the same logic as seed.ts.
+function nextDateForWeekday(base: Date, weekday: string): Date {
+    const target = weekdayMap[weekday]!;
+    const date = new Date(base);
+    const diff = (target - date.getDay() + 7) % 7;
+    date.setDate(date.getDate() + diff);
+    return date;
+}
+
+// generateWeeklySchedules
+// Main export. Generates Schedule rows for the coming week.
+//
+// Steps:
+//   1. Compute the date range for next week (Monday–Sunday)
+//   2. Fetch all ACTIVE ActivityTemplates with their timeSlots
+//   3. For each timeSlot, check if a schedule already exists in that range
+//   4. If not, create one with status ACTIVE
+//
+// Safe to call multiple times — the existence check prevents duplicates.
+export async function generateWeeklySchedules(): Promise<void> {
+    const now = new Date();
+    const nextMon = nextWeek(now, 1);              // base = one week ahead
+    const { startDay, endDay } = startAndEndOfWeek(nextMon);
+
+    console.log(`[cron] Generating schedules for ${startDay.toDateString()} – ${endDay.toDateString()}`);
+
+    // 1. Fetch all active activity templates with their time slots
+    const activities = await prisma.activityTemplate.findMany({
+        where: { defaultStatus: ActivityStatus.ACTIVE },
+        include: { timeSlots: true },
+    });
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const activity of activities) {
+        for (const slot of activity.timeSlots) {
+
+            // 2. Compute the exact date for this slot next week
+            const slotDate = nextDateForWeekday(startDay, slot.weekday);
+
+            const startAt = new Date(slotDate);
+            startAt.setUTCHours(
+                slot.startTime.getUTCHours(),
+                slot.startTime.getUTCMinutes(),
+                0,
+                0,
+            );
+
+            const endAt = new Date(slotDate);
+            endAt.setUTCHours(
+                slot.endTime.getUTCHours(),
+                slot.endTime.getUTCMinutes(),
+                0,
+                0,
+            );
+
+            // 3. Check if a schedule already exists for this slot
+            const existing = await prisma.schedule.findFirst({
+                where: {
+                    activityId: activity.id,
+                    startAt: { gte: startDay, lte: endDay },
+                },
+            });
+
+            if (existing) {
+                skipped++;
+                continue;
+            }
+
+            // 4. Create the schedule
+            await prisma.schedule.create({
+                data: {
+                    activityId: activity.id,
+                    startAt,
+                    endAt,
+                    status: ActivityStatus.ACTIVE,
+                },
+            });
+
+            created++;
+        }
+    }
+
+    console.log(`[cron] Done — ${created} schedules created, ${skipped} already existed.`);
+}

--- a/server/src/cron/scheduleGenerator.ts
+++ b/server/src/cron/scheduleGenerator.ts
@@ -1,7 +1,7 @@
 // server/src/cron/scheduleGenerator.ts
 //
 // Core logic for generating Schedule rows for the coming week.
-// Called by the cron job every Monday at 00:01, and once on
+// Called by the cron job every Monday at 00:05, and once on
 // server startup as a fallback (in case the server was down on Monday).
 
 import { prisma, ActivityStatus } from '../db/prisma.js';
@@ -43,7 +43,7 @@ function nextDateForWeekday(base: Date, weekday: string): Date {
 // Safe to call multiple times — the existence check prevents duplicates.
 export async function generateWeeklySchedules(): Promise<void> {
     const now = new Date();
-    const nextMon = nextWeek(now, 1);              // base = one week ahead
+    const nextMon = nextWeek(now, 1);  // 1 = one week ahead
     const { startDay, endDay } = startAndEndOfWeek(nextMon);
 
     console.log(`[cron] Generating schedules for ${startDay.toDateString()} – ${endDay.toDateString()}`);
@@ -62,7 +62,7 @@ export async function generateWeeklySchedules(): Promise<void> {
 
             // 2. Compute the exact date for this slot next week
             const slotDate = nextDateForWeekday(startDay, slot.weekday);
-
+            // Times are stored in UTC — slot.startTime and slot.endTime are UTC Date objects
             const startAt = new Date(slotDate);
             startAt.setUTCHours(
                 slot.startTime.getUTCHours(),
@@ -79,11 +79,18 @@ export async function generateWeeklySchedules(): Promise<void> {
                 0,
             );
 
+
+            // TODO: For large datasets, consider fetching all existing schedules upfront
+            // and doing an in-memory check instead of N*M sequential DB queries.
+
+
+
             // 3. Check if a schedule already exists for this slot
             const existing = await prisma.schedule.findFirst({
                 where: {
                     activityId: activity.id,
                     startAt,
+                    endAt,
                 },
             });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,10 @@
 import 'dotenv/config';
 import { app } from './app.js';
+import { initCronJobs } from './cron/index.js';
 
 const PORT = Number(process.env['PORT']) || 3001;
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
+  initCronJobs();
 });


### PR DESCRIPTION
## What 
Automatically generates `Schedule` rows for the coming week every Monday at 00:01 using `node-cron`. Closes #56.

## The reason for implementing CRON:
Schedules were previously seeded manually. This automates the process so the app stays up to date without any manual intervention.

## Changes
- Installed `node-cron` + `@types/node-cron`
- `server/src/cron/scheduleGenerator.ts` - core generation logic:
  - Fetches all `ACTIVE` ActivityTemplates with their timeSlots
  - Computes the correct date for each slot in the coming week
  - Checks for existing schedules before creating (no duplicates possible)
  - Creates new `Schedule` rows with status `ACTIVE`
- `server/src/cron/index.ts` - cron job setup:
  - Registers the Monday 00:01 job
  - Runs a startup check on server boot as a fallback (in case the server was down on Monday)
- `server/src/server.ts` - wires `initCronJobs()` into the server startup

## What to test
- Start the server and check the console - you should see `[cron] Running startup schedule check...` followed by how many schedules were created or already existed
- Verify no duplicate schedules are created if you restart the server multiple times

<img width="673" height="214" alt="image" src="https://github.com/user-attachments/assets/139de1c2-85c3-44d5-ac4d-9509842ecb1e" />


## Notes
- Reuses `nextDateForWeekday()` logic from `seed.ts` and existing utils from `weekCalculator.ts`
- Past-week cleanup is out of scope and tracked as a follow-up