### PR TITLE
77 adminboard member activity management on profile page

### DIFF
--- a/client/src/components/skeletons/ProfileSkeleton.jsx
+++ b/client/src/components/skeletons/ProfileSkeleton.jsx
@@ -1,0 +1,242 @@
+// Skeleton placeholder for /profile.
+//
+// Mirrors the real ProfilePage layout so the page doesn't visually
+// jump when /api/users/me resolves. Sections rendered:
+//   1. Hero / user card     — always
+//   2. Manage Activities    — only if canManage (ADMIN / BOARD_MEMBER)
+//   3. Upcoming Activities  — always
+//   4. Favorite Activities  — always
+//
+// Why a single page-level skeleton instead of one-per-section:
+//   The hero + upcoming + favorites all land together when
+//   /api/users/me resolves, so splitting the file would just add
+//   import boilerplate without a real win.
+//
+// We also export ManageActivitiesGridSkeleton because the manage
+// list is fetched independently from the main profile call (see
+// ProfilePage's second useEffect), so the rest of the page can
+// already be visible while the management grid is still in flight.
+
+import React from 'react'
+import { Card, Skeleton } from '../ui'
+
+// ── Section heading placeholder ────────────────────────────────
+// Small helper so all three section titles look identical and we
+// only have to tweak one place if the typography changes.
+function SectionHeadingSkeleton() {
+  return (
+    <Skeleton
+      height="1.5rem"
+      width="35%"
+      style={{ marginBottom: '16px' }}
+    />
+  )
+}
+
+// ── Hero card placeholder ──────────────────────────────────────
+// Mirrors the green user card at the top of the profile: large
+// name, email line, role badge pill.
+function HeroSkeleton() {
+  return (
+    <Card
+      padding="lg"
+      shadow="md"
+      style={{
+        marginBottom: '32px',
+        background: 'var(--color-primary-light)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      {/* Name — h1 sized */}
+      <Skeleton
+        height="2.5rem"
+        width="40%"
+        style={{ marginBottom: '8px' }}
+      />
+
+      {/* Email — muted text line */}
+      <Skeleton
+        height="1rem"
+        width="30%"
+        style={{ marginBottom: '12px' }}
+      />
+
+      {/* Role pill — width chosen to roughly match a BOARD_MEMBER badge */}
+      <Skeleton height="1.4rem" width="120px" radius="full" />
+    </Card>
+  )
+}
+
+// ── Manage Activities grid placeholder ─────────────────────────
+// Exported so ProfilePage can also use it for the secondary
+// `manageLoading` state (when the rest of the page is already
+// painted but the manage list is still in flight).
+//
+// count default of 3 fits one row on most viewports — same logic
+// as ActivityListSkeleton's default of 4 (enough to feel populated,
+// not so many we waste DOM nodes).
+export function ManageActivitiesGridSkeleton({ count = 3 }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns:
+          'repeat(auto-fit, minmax(280px, 1fr))',
+        gap: '20px',
+      }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <Card
+          key={i}
+          padding="md"
+          shadow="sm"
+          style={{ position: 'relative' }}
+        >
+          {/* Pen icon placeholder — top-right circle. Mirrors the
+              ✎ button on the real card. */}
+          <Skeleton
+            radius="full"
+            width="24px"
+            height="24px"
+            style={{
+              position: 'absolute',
+              top: '12px',
+              right: '12px',
+            }}
+          />
+
+          {/* Card title — leaves room for the pen */}
+          <Skeleton
+            height="1.3rem"
+            width="60%"
+            style={{ marginBottom: '12px' }}
+          />
+
+          {/* Location line */}
+          <Skeleton
+            height="1rem"
+            width="50%"
+            style={{ marginBottom: '16px' }}
+          />
+
+          {/* Edit Activity button placeholder */}
+          <Skeleton height="2rem" width="120px" radius="sm" />
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+// ── Upcoming Activities grid placeholder ───────────────────────
+// Compact cards — real version is just name + date, so the
+// skeleton is intentionally short to avoid over-rendering.
+function UpcomingGridSkeleton({ count = 3 }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns:
+          'repeat(auto-fit, minmax(240px, 1fr))',
+        gap: '16px',
+      }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i} padding="md" shadow="sm">
+          <Skeleton
+            height="1.2rem"
+            width="65%"
+            style={{ marginBottom: '8px' }}
+          />
+          <Skeleton height="1rem" width="45%" />
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+// ── Favorite Activities grid placeholder ───────────────────────
+// Tallest of the three section types — real favorites card has
+// name, description, location, and a Remove button.
+function FavoritesGridSkeleton({ count = 3 }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns:
+          'repeat(auto-fit, minmax(280px, 1fr))',
+        gap: '20px',
+      }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i} padding="md" shadow="sm">
+          <Skeleton
+            height="1.3rem"
+            width="60%"
+            style={{ marginBottom: '10px' }}
+          />
+
+          {/* Description — two lines of muted text */}
+          <Skeleton height="1rem" style={{ marginBottom: '6px' }} />
+          <Skeleton
+            height="1rem"
+            width="80%"
+            style={{ marginBottom: '14px' }}
+          />
+
+          {/* Location line */}
+          <Skeleton
+            height="1rem"
+            width="55%"
+            style={{ marginBottom: '16px' }}
+          />
+
+          {/* Remove Favorite button placeholder */}
+          <Skeleton height="2rem" width="140px" radius="sm" />
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+// ── Default export: full page skeleton ─────────────────────────
+// Props:
+//   canManage — when true, also renders the Manage Activities
+//               section so the layout matches what the user is
+//               about to see. Passed in from ProfilePage which
+//               already computes it from user.role.
+export default function ProfileSkeleton({ canManage = false }) {
+  return (
+    <div
+      style={{
+        padding: 'var(--space-6)',
+        maxWidth: '1100px',
+        margin: '0 auto',
+      }}
+      aria-busy="true"
+      // aria-busy tells assistive tech the region is updating.
+      // Individual Skeleton bars are aria-hidden so they don't
+      // get announced individually — only this wrapper does.
+    >
+      <HeroSkeleton />
+
+      {/* Manage section sits above Upcoming when applicable,
+          mirroring the real page order for ADMIN / BOARD_MEMBER. */}
+      {canManage && (
+        <div style={{ marginBottom: '32px' }}>
+          <SectionHeadingSkeleton />
+          <ManageActivitiesGridSkeleton />
+        </div>
+      )}
+
+      <div style={{ marginBottom: '32px' }}>
+        <SectionHeadingSkeleton />
+        <UpcomingGridSkeleton />
+      </div>
+
+      <div>
+        <SectionHeadingSkeleton />
+        <FavoritesGridSkeleton />
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import {
   removeFavorite,
@@ -6,16 +7,29 @@ import {
 import {
   fetchProfile,
 } from '../services/ProfileService.js'
+import {
+  fetchManageableActivities,
+} from '../services/ManageActivitiesService.js'
+import { MANAGER_ROLES } from '../constants/roles.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
 import Badge, {
   ROLE_VARIANT,
+  STATUS_VARIANT,
 } from '../components/ui/Badge.jsx'
 
 export default function ProfilePage() {
 
-  // ── Auth ────────────────────────────────────────────────
+// ── Auth ────────────────────────────────────────────────
   const { user, token } = useAuth()
+  const navigate = useNavigate()
+
+  // ── Role gate ───────────────────────────────────────────
+  // Single source of truth for "should this user see the
+  // Manage Activities section?" — used both to skip the fetch
+  // in step 2's effect and to conditionally render the section
+  // below. Computed here so both spots can't drift apart.
+  const canManage = MANAGER_ROLES.includes(user?.role)
 
   // ── State ───────────────────────────────────────────────
 
@@ -32,6 +46,22 @@ export default function ProfilePage() {
     = useState(true)
   
   const [error, setError] = useState(null)
+
+  // ── Manage Activities state (ADMIN / BOARD_MEMBER only) ─
+  // Populated by a separate effect below that only fires for
+  // users with a role in MANAGER_ROLES. For MEMBER / LEADER the
+  // array stays empty and the Manage Activities section just
+  // doesn't render (step 3).
+  //
+  // manageLoading is tracked independently from the main `loading`
+  // flag so the favorites/participations sections aren't blocked
+  // waiting for this extra fetch — the hero card and existing
+  // sections can paint as soon as /api/users/me resolves.
+  const [manageableActivities, setManageableActivities]
+    = useState([])
+
+  const [manageLoading, setManageLoading]
+    = useState(false)
 
   // ── Fetch Profile ───────────────────────────────────────
   // Loads all profile-related data from a single endpoint:
@@ -82,6 +112,58 @@ export default function ProfilePage() {
     loadProfile()
 
   }, [token])
+
+  // ── Fetch Manageable Activities ─────────────────────────
+  // Only ADMIN and BOARD_MEMBER see the Manage Activities
+  // section, so we only hit the network for those roles.
+  // Gating client-side avoids a pointless fetch for every
+  // MEMBER who opens their profile.
+  //
+  // user?.role guards against the brief render where AuthContext
+  // is still rehydrating from localStorage and user is null —
+  // re-running once role is available is fine, the dependency
+  // array picks it up.
+  //
+  // Note: backend access control is still the real enforcement
+  // layer — the endpoint is public so any role *could* call it,
+  // but a MEMBER has no UI to act on the data.
+  useEffect(() => {
+
+    if (!user?.role) return
+
+    if (!MANAGER_ROLES.includes(user.role)) return
+
+    async function loadManageableActivities() {
+
+      setManageLoading(true)
+
+      try {
+
+        const { data } =
+          await fetchManageableActivities()
+
+        setManageableActivities(data || [])
+
+      } catch (error) {
+
+        // Soft-fail: log but don't block the rest of the page.
+        // The favorites + participations sections are still useful
+        // even if the management list fails to load. We'll surface
+        // an empty-state message in step 3.
+        console.error(
+          'Failed to load manageable activities:',
+          error
+        )
+
+      } finally {
+
+        setManageLoading(false)
+      }
+    }
+
+    loadManageableActivities()
+
+  }, [user?.role])
 
   // ── Remove Favorite ─────────────────────────────────────
   async function handleRemoveFavorite(activityId) {
@@ -210,6 +292,164 @@ export default function ProfilePage() {
         </div>
 
       </Card>
+
+      {/* ── Manage Activities (ADMIN / BOARD_MEMBER only) ─
+          Rendered above Upcoming/Favorites because for these
+          roles the management dashboard *is* the primary use
+          of /profile — favorites/upcoming are secondary.
+          Hidden entirely for MEMBER and LEADER (LEADER has its
+          own dashboard in a separate ticket). */}
+      {canManage && (
+
+        <div style={{ marginBottom: '32px' }}>
+
+          <h2
+            style={{
+              marginBottom: '16px',
+              fontSize: '1.5rem',
+            }}
+          >
+            Manage Activities
+          </h2>
+
+          {/* Three render states:
+              1. manageLoading       — fetch in flight
+              2. empty array         — nothing to manage yet
+              3. populated array     — the grid of cards
+              Kept inline (no extracted sub-component) to match
+              the pattern already used by Upcoming / Favorites
+              below — easier to read in one place for review. */}
+          {manageLoading ? (
+
+            <Card padding="md">
+              <p>Loading activities...</p>
+            </Card>
+
+          ) : manageableActivities.length === 0 ? (
+
+            <Card padding="md">
+              <p>No activities to manage yet.</p>
+            </Card>
+
+          ) : (
+
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns:
+                  'repeat(auto-fit, minmax(280px, 1fr))',
+                gap: '20px',
+              }}
+            >
+
+              {manageableActivities.map(activity => (
+
+                <Card
+                  key={activity.id}
+                  padding="md"
+                  shadow="sm"
+                  style={{
+                    // position: relative so the absolutely
+                    // positioned edit-pen anchors to this card.
+                    // Same pattern ActivitiesPage uses for the
+                    // heart-favorite button.
+                    position: 'relative',
+                  }}
+                >
+
+                  {/* ── Quick-edit pen (top-right) ──────────
+                      Mirrors the heart-button on ActivitiesPage
+                      so the interaction feels familiar. Routes
+                      straight to the existing edit form — no new
+                      page needed since /activities/:id/edit is
+                      already wired up in App.jsx and protected
+                      by EDITOR_ROLES. */}
+                  <button
+                    onClick={() =>
+                      navigate(`/activities/${activity.id}/edit`)
+                    }
+                    aria-label={`Edit ${activity.name}`}
+                    title="Edit activity"
+                    style={{
+                      position: 'absolute',
+                      top: '12px',
+                      right: '12px',
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      fontSize: '1.25rem',
+                      color: 'var(--color-text-muted)',
+                      padding: '4px 8px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    ✎
+                  </button>
+
+                  {/* Title + status badge.
+                      paddingRight leaves room for the pen so
+                      long activity names don't run under it. */}
+                  <h3
+                    style={{
+                      marginBottom: '8px',
+                      paddingRight: '32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    {activity.name}
+
+                    {activity.defaultStatus === 'CANCELLED' && (
+                      <Badge
+                        variant={
+                          STATUS_VARIANT[activity.defaultStatus]
+                        }
+                      >
+                        Cancelled
+                      </Badge>
+                    )}
+                  </h3>
+
+                  <p
+                    style={{
+                      color: 'var(--color-text-muted)',
+                      marginBottom: '12px',
+                      fontSize: '0.9rem',
+                    }}
+                  >
+                    <strong>Location:</strong>{' '}
+                    {activity.location}
+                  </p>
+
+                  {/* Explicit "Edit Activity" button.
+                      The pen is a fast-path for power users; this
+                      button is the obvious, labelled action for
+                      anyone who doesn't recognise the icon. Both
+                      navigate to the same place — duplication is
+                      intentional for discoverability. */}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      navigate(`/activities/${activity.id}/edit`)
+                    }
+                  >
+                    Edit Activity
+                  </Button>
+
+                </Card>
+
+              ))}
+
+            </div>
+
+          )}
+
+        </div>
+
+      )}
 
       {/* ── Upcoming Activities ────────────────────────── */}
       <div style={{ marginBottom: '32px' }}>

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -297,14 +297,50 @@ export default function ProfilePage() {
 
         <div style={{ marginBottom: '32px' }}>
 
-          <h2
+          {/* Section header row: title on the left, primary
+              action on the right. Flex layout (not the bare
+              h2 we had before) so the "Create New Activity"
+              button can sit inline with the heading. Wraps on
+              narrow viewports so the button drops below the
+              title instead of overflowing.
+              The button is rendered here — outside the
+              loading / empty / populated branches below — so
+              it's always available regardless of whether the
+              manage list is loaded, empty, or in flight.
+              Creating a new activity doesn't depend on the
+              existing list at all. */}
+          <div
             style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
               marginBottom: '16px',
-              fontSize: '1.5rem',
+              flexWrap: 'wrap',
+              gap: '12px',
             }}
           >
-            Manage Activities
-          </h2>
+
+            <h2 style={{ fontSize: '1.5rem' }}>
+              Manage Activities
+            </h2>
+
+            {/* Routes to /activities/new — already exists in
+                App.jsx and is also protected by MANAGER_ROLES,
+                so the same users who see this button are the
+                same ones who can reach the form. The route
+                reuses ActivityFormPage (same component as the
+                edit flow), the form just detects the missing
+                :id and renders in create mode. */}
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => navigate('/activities/new')}
+            >
+              + Create New Activity
+            </Button>
+
+          </div>
+
 
           {/* Three render states:
               1. manageLoading       — fetch in flight

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -17,6 +17,9 @@ import Badge, {
   ROLE_VARIANT,
   STATUS_VARIANT,
 } from '../components/ui/Badge.jsx'
+import ProfileSkeleton, {
+  ManageActivitiesGridSkeleton,
+} from '../components/skeletons/ProfileSkeleton.jsx'
 
 export default function ProfilePage() {
 
@@ -193,23 +196,14 @@ export default function ProfilePage() {
     }
   }
 
-  // ── Loading State ───────────────────────────────────────
+// ── Loading State ───────────────────────────────────────
+  // Renders the full page shape as shimmering placeholders so
+  // the layout doesn't jump when /api/users/me resolves.
+  // canManage is already available here — AuthContext hydrates
+  // user.role from localStorage before the profile fetch fires.
   if (loading) {
-    return (
-      <div
-        style={{
-          padding: 'var(--space-6)',
-          maxWidth: '1100px',
-          margin: '0 auto',
-        }}
-      >
-        <Card padding="lg">
-          <p>Loading profile...</p>
-        </Card>
-      </div>
-    )
+    return <ProfileSkeleton canManage={canManage} />
   }
-
   // ── Error State ───────────────────────────────────────
   if (error) {
   return (
@@ -321,9 +315,9 @@ export default function ProfilePage() {
               below — easier to read in one place for review. */}
           {manageLoading ? (
 
-            <Card padding="md">
-              <p>Loading activities...</p>
-            </Card>
+            // Shares the same shape as the real grid below, so
+            // when the fetch lands the card layout doesn't shift.
+            <ManageActivitiesGridSkeleton />
 
           ) : manageableActivities.length === 0 ? (
 

--- a/client/src/services/ManageActivitiesService.js
+++ b/client/src/services/ManageActivitiesService.js
@@ -1,0 +1,47 @@
+// All API calls for fetching activities that an ADMIN or BOARD_MEMBER
+// can manage live here. ProfilePage (Manage Activities section) imports
+// these — nothing else should call them directly.
+//
+// Why a separate service instead of reusing the inline fetch in
+// ActivitiesPage:
+//   - ProfilePage is opening a *management* view, not a browse view.
+//     Keeping the call behind a named function documents intent and
+//     gives us one place to swap in a scoped endpoint later (e.g. when
+//     LEADER's "my activities" ticket lands and we need filtering by
+//     ownership).
+//   - Matches the FavoritesService / ProfileService pattern already
+//     used in the project — pages call services, services own fetch().
+
+import { API_BASE_URL } from './apiConfig.js'
+
+const BASE = `${API_BASE_URL}/api/activities`
+
+// ── fetchManageableActivities ─────────────────────────────────
+// GET /api/activities
+//
+// Returns the full JSON body: { status, data: [...activities] }
+// Callers should destructure `.data` (same convention as fetchProfile
+// and fetchFavorites).
+//
+// Auth note:
+//   This endpoint is currently PUBLIC on the backend
+//   (see server/src/routes/activities.routes.ts → router.get('', ...))
+//   so no Authorization header is sent. For ADMIN / BOARD_MEMBER the
+//   "manageable" set is just every activity in the system, so the
+//   public list is exactly what we want — we don't need to filter
+//   client-side.
+//
+//   No AuthExpiredError handling for the same reason: the endpoint
+//   doesn't read the token, so it can't reject one. If we later add a
+//   protected /api/users/me/managed-activities endpoint, plumb the
+//   token + 401 check in here the same way FavoritesService does it.
+export async function fetchManageableActivities() {
+
+  const response = await fetch(BASE)
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch manageable activities')
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## what this pr includes
- new "manage activities" section on `/profile`, only visible to ADMIN and BOARD_MEMBER
- each card has a ✎ pen in the top-right + an "Edit Activity" button, both jump straight to `/activities/:id/edit`
- swapped the old "Loading profile..." card for a proper page skeleton that mirrors the real layout (matches what we already do on ActivitiesPage with ActivityListSkeleton)


## files touched
- `client/src/services/ManageActivitiesService.js` — new, wraps `GET /api/activities`. kept in its own file so we can later swap to a scoped endpoint without touching the page
- `client/src/components/skeletons/ProfileSkeleton.jsx` — new, full-page skeleton + an exported `ManageActivitiesGridSkeleton` we reuse for the inner manage-loading state
- `client/src/pages/ProfilePage.jsx` — wires it all together: role gate, fetch effect, new section, skeleton

## how to test
- log in as ADMIN or BOARD_MEMBER → manage section should appear above upcoming / favorites, with the pen icon and edit button on every card
- log in as MEMBER → manage section should not appear at all (and no `/api/activities` call in the network tab)
- log in as LEADER → also no manage section (leader's own dashboard is a separate ticket #YY, on purpose here)
- click either the ✎ or the "Edit Activity" button → should land on `/activities/:id/edit` with the form prefilled
- throttle network to slow 3G in devtools → page skeleton should match the real layout, no shift when data arrives

## notes for review
- `GET /api/activities` is public + unscoped right now, so the page just pulls everything. for ADMIN/BOARD_MEMBER "manageable" = everything which is fine. if we later add per-role filtering, only the service file needs to change
- backend role checks on `PUT /api/activities/:id` are already in place, so even if a MEMBER somehow opened the edit URL by hand the server would block the save