### PR TITLE
fix(server): resolve schedule query participation counts and date validation issues

### DIFF
--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -113,6 +113,9 @@ export class CREATE {
                 status: finalStatus
             },
             include: {
+                _count: {
+                    select: { participations: true }
+                },
                 activity: {
                     include: {
                         leaders: {

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -227,6 +227,9 @@ export class READ {
             select: {
                 schedule: {
                     include: {
+                        _count: {
+                            select: { participations: true }
+                        },
                         activity: {
                             include: {
                                 leaders: {
@@ -261,7 +264,7 @@ export class READ {
                 status: el.schedule.status,
                 activity: el.schedule.activity,
                 leaders: leaders,
-                participantCount: 0
+                participantCount: el.schedule._count?.participations ?? 0
             } satisfies ScheduleDto)
         })
 
@@ -280,6 +283,9 @@ export class READ {
                     select: {
                         schedule: {
                             include: {
+                                _count: {
+                                    select: { participations: true }
+                                },
                                 activity: {
                                     include: {
                                         leaders: {

--- a/server/src/db/updateQueries.ts
+++ b/server/src/db/updateQueries.ts
@@ -120,6 +120,9 @@ export class UPDATE {
             where: { id: scheduleId },
             data,
             include: {
+                _count: {
+                    select: { participations: true }
+                },
                 activity: {
                     include: {
                         leaders: {

--- a/server/src/validators/schedule.validator.ts
+++ b/server/src/validators/schedule.validator.ts
@@ -1,9 +1,10 @@
 import * as z from "zod";
 
 export const ScheduleDateSchema = z.nullish(z.union([
-    z.iso.date(),
+    z.string().date(),
+    z.string().datetime(),
     z.literal("today")
-])).default(new Date().toISOString());
+])).default(() => new Date().toISOString());
 
 export const ScheduleBoolWeekSchema = z.nullish(z.stringbool()).default(true);
 


### PR DESCRIPTION
## What this does
Fixes Date Validation Crashes: Updates the `ScheduleDateSchema` validator to support full ISO datetime strings as well as short date strings (YYYY-MM-DD).

Corrects Participant Spot Counting: Adds database query inclusions and mapping logic to ensure that a schedule's participantCount accurately reflects the number of registered attendees in the database.

## Why this is necessary
Validation: The Zod validator previously used `z.iso.date()`, which only accepts short dates. If a client queried with a full ISO datetime string (which was also generated as the validator's own default value), the endpoint would crash with a validation error.

Incorrect Capacities: The client-side interface relies on `participantCount` to calculate available spots. Previously, the backend queries for creating, updating, and fetching a user's joined/profile schedules either omitted this count entirely or hardcoded it to 0. This resulted in the client showing incorrect spots remaining.