### PR TITLE
feat: stats dashboard fully implemented.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.4.0",
@@ -775,6 +776,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1127,6 +1164,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1172,11 +1221,80 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1269,12 +1387,142 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1294,12 +1542,28 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.345",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
       "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1370,6 +1634,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1411,6 +1681,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1577,6 +1866,37 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1618,6 +1938,58 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -1707,6 +2079,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1753,6 +2131,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,11 +9,11 @@
     "lint": "eslint .",
     "preview": "vite preview"
   },
-
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.4.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,8 @@ import ActivityFormPage from './pages/ActivityFormPage.jsx'
 import SchedulePage from './pages/SchedulePage.jsx'
 import ProfilePage from './pages/ProfilePage.jsx'
 import ActivityDetailPage from './pages/ActivityDetailPage.jsx'
-import { MANAGER_ROLES, EDITOR_ROLES } from './constants/roles.js'
+import StatisticsPage from './pages/StatisticsPage.jsx'
+import { MANAGER_ROLES, EDITOR_ROLES, ROLES } from './constants/roles.js'
 import NotFoundPage from './pages/NotFoundPage.jsx'
 import AboutPage from "./pages/AboutPage.jsx";
 
@@ -158,6 +159,20 @@ function AppRoutes() {
             element={
               <ProtectedRoute>
                 <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Admin-only statistics dashboard.
+              Gate is [ROLES.ADMIN] specifically (not MANAGER_ROLES)
+              because the backend endpoint /api/admin/statistics is
+              restrictToMinRole(ADMIN). A BOARD_MEMBER reaching this
+              page would just get a 403 → bad UX. */}
+          <Route
+            path="/admin/statistics"
+            element={
+              <ProtectedRoute requiredRoles={[ROLES.ADMIN]}>
+                <StatisticsPage />
               </ProtectedRoute>
             }
           />

--- a/client/src/components/skeletons/StatisticsSkeleton.jsx
+++ b/client/src/components/skeletons/StatisticsSkeleton.jsx
@@ -1,0 +1,178 @@
+// Skeleton placeholder for /admin/statistics.
+//
+// Mirrors the real StatisticsPage layout so the page doesn't
+// visually jump when /api/admin/statistics resolves. Sections:
+//   1. Header row              — title + meta + action buttons
+//   2. KPI tiles               — 4 metric cards in a row
+//   3. Popular activities chart card
+//   4. Participants per activity chart card
+//   5. Cancellation rate chart card
+//
+// Why a single page-level skeleton instead of one-per-section:
+//   All three charts come from a single /api/admin/statistics
+//   call — they land at the same moment, so per-section
+//   placeholders would never appear independently. One file
+//   keeps the layout match obvious during review.
+
+import React from 'react'
+import { Card, Skeleton } from '../ui'
+
+// ── Section heading placeholder ────────────────────────────────
+// Reused by all three chart cards so titles stay consistent.
+function ChartHeadingSkeleton() {
+  return (
+    <>
+      {/* Chart title */}
+      <Skeleton
+        height="1.3rem"
+        width="40%"
+        style={{ marginBottom: '8px' }}
+      />
+
+      {/* Subtitle / description line — muted text under title */}
+      <Skeleton
+        height="0.9rem"
+        width="60%"
+        style={{ marginBottom: '20px' }}
+      />
+    </>
+  )
+}
+
+// ── Header row placeholder ─────────────────────────────────────
+// Mirrors the real header: page title + "Last updated..." line
+// on the left, Refresh + Export CSV buttons on the right.
+function HeaderSkeleton() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: '24px',
+        flexWrap: 'wrap',
+        gap: '12px',
+      }}
+    >
+
+      {/* Left side: title + last-updated meta */}
+      <div>
+
+        {/* Page title — h1 sized */}
+        <Skeleton
+          height="2rem"
+          width="280px"
+          style={{ marginBottom: '8px' }}
+        />
+
+        {/* "Last updated X ago" line */}
+        <Skeleton height="0.9rem" width="180px" />
+
+      </div>
+
+      {/* Right side: two action buttons (Refresh, Export CSV) */}
+      <div
+        style={{
+          display: 'flex',
+          gap: '8px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Skeleton height="2rem" width="100px" radius="sm" />
+        <Skeleton height="2rem" width="120px" radius="sm" />
+      </div>
+
+    </div>
+  )
+}
+
+// ── KPI tiles placeholder ──────────────────────────────────────
+// Four equal-width cards. Each has a small label on top and a
+// large number below — matches the real KPI tile shape.
+function KpiTilesSkeleton() {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns:
+          'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: '16px',
+        marginBottom: '32px',
+      }}
+    >
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i} padding="md" shadow="sm">
+
+          {/* Metric label — small, muted */}
+          <Skeleton
+            height="0.85rem"
+            width="65%"
+            style={{ marginBottom: '12px' }}
+          />
+
+          {/* Metric value — large number */}
+          <Skeleton height="2rem" width="50%" />
+
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+// ── Chart card placeholder ─────────────────────────────────────
+// Shared by all three chart sections. The `height` prop matches
+// the real chart's ResponsiveContainer height so the page
+// doesn't shift when the chart renders.
+//
+// Default 320px matches the real chart height — keep in sync if
+// the chart cards change.
+function ChartCardSkeleton({ height = 320 }) {
+  return (
+    <Card
+      padding="lg"
+      shadow="sm"
+      style={{ marginBottom: '24px' }}
+    >
+      <ChartHeadingSkeleton />
+
+      {/* Chart area — a single tall skeleton block stands in
+          for the actual chart. We don't try to mimic individual
+          bars because the real chart count varies with data,
+          and a plain block reads as "chart loading" cleanly. */}
+      <Skeleton
+        height={`${height}px`}
+        radius="md"
+      />
+    </Card>
+  )
+}
+
+// ── Default export: full page skeleton ─────────────────────────
+// No props — the statistics page layout is identical for every
+// ADMIN viewer, so there's nothing to vary (unlike ProfileSkeleton
+// which has a canManage prop).
+export default function StatisticsSkeleton() {
+  return (
+    <div
+      style={{
+        padding: 'var(--space-6)',
+        maxWidth: '1100px',
+        margin: '0 auto',
+      }}
+      aria-busy="true"
+      // aria-busy tells assistive tech this region is updating.
+      // Individual Skeleton bars are aria-hidden so they don't
+      // get announced one by one — only this wrapper does.
+    >
+      <HeaderSkeleton />
+
+      <KpiTilesSkeleton />
+
+      {/* Three chart cards stacked vertically — same order as
+          the real page so layout matches one-to-one. */}
+      <ChartCardSkeleton />
+      <ChartCardSkeleton />
+      <ChartCardSkeleton />
+    </div>
+  )
+}

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -10,7 +10,7 @@ import {
 import {
   fetchManageableActivities,
 } from '../services/ManageActivitiesService.js'
-import { MANAGER_ROLES } from '../constants/roles.js'
+import { MANAGER_ROLES, ROLES } from '../constants/roles.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
 import Badge, {
@@ -33,6 +33,12 @@ export default function ProfilePage() {
   // in step 2's effect and to conditionally render the section
   // below. Computed here so both spots can't drift apart.
   const canManage = MANAGER_ROLES.includes(user?.role)
+
+  // Statistics dashboard is ADMIN-only — strictly narrower than
+  // canManage because the backend endpoint is ADMIN-gated.
+  // Computed alongside canManage so both role checks live in
+  // the same spot and can't drift apart.
+  const isAdmin = user?.role === ROLES.ADMIN
 
   // ── State ───────────────────────────────────────────────
 
@@ -282,6 +288,25 @@ export default function ProfilePage() {
             </Badge>
 
           </div>
+
+          {/* ── Admin-only quick action ─────────────────────
+              Entry point to /admin/statistics. Only rendered
+              for ADMIN — BOARD_MEMBER doesn't see this even
+              though they see the manage section below, because
+              the stats endpoint is ADMIN-only on the backend.
+              Sits inside the hero card's flex row so it floats
+              to the right of the user info on desktop and wraps
+              below on narrow viewports (the row already has
+              flexWrap: 'wrap'). */}
+          {isAdmin && (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => navigate('/admin/statistics')}
+            >
+              📊 Open Statistics
+            </Button>
+          )}
 
         </div>
 

--- a/client/src/pages/StatisticsPage.jsx
+++ b/client/src/pages/StatisticsPage.jsx
@@ -1,0 +1,887 @@
+// /admin/statistics
+//
+// Admin-only dashboard. Visualises aggregate data from
+// GET /api/admin/statistics:
+//   - 4 KPI tiles at the top
+//   - 3 recharts charts below (popular / participants / cancellation)
+//
+// Extra UX:
+//   - "Last updated X ago" stamp + manual refresh button
+//   - CSV export of the merged per-activity table
+//
+// Role gate is enforced in App.jsx via <ProtectedRoute requiredRoles=
+// {[ROLES.ADMIN]}>. The backend also restricts to ADMIN — the route
+// guard just prevents the page from mounting and firing a doomed
+// request for non-admins.
+
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+
+import { useAuth } from '../context/AuthContext.jsx'
+import {
+  fetchAdminStatistics,
+} from '../services/AdminStatisticsService.js'
+import { AuthExpiredError } from '../services/AuthExpiredError.js'
+
+import Card from '../components/ui/Card.jsx'
+import Button from '../components/ui/Button.jsx'
+import StatisticsSkeleton from
+  '../components/skeletons/StatisticsSkeleton.jsx'
+
+
+// ── Chart color tokens ─────────────────────────────────────────
+// Pulled into named constants so the three charts stay visually
+// consistent and so future palette tweaks happen in one place
+// instead of scattered across <Bar fill="#..."> props.
+// All values are the CSS custom properties already defined in
+// index.css — no new colors introduced.
+const COLOR_PRIMARY     = 'var(--color-primary)'
+const COLOR_PRIMARY_MID = 'var(--color-primary-mid)'
+const COLOR_DANGER      = 'var(--color-danger)'
+const COLOR_TEXT_MUTED  = 'var(--color-text-muted)'
+const COLOR_BORDER      = 'var(--color-border)'
+
+
+// ── relativeTimeFrom ──────────────────────────────────────────
+// Returns a short human string for "how long ago was this Date?".
+// Used by the "Last updated X ago" label in the header.
+//
+// Kept outside the component so it doesn't get redefined on every
+// render. No external library needed — the granularity we want
+// (just-now / minutes / hours) is trivial to compute by hand.
+function relativeTimeFrom(date) {
+
+  if (!date) return ''
+
+  const seconds =
+    Math.floor((Date.now() - date.getTime()) / 1000)
+
+  if (seconds < 10)   return 'just now'
+  if (seconds < 60)   return `${seconds}s ago`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60)   return `${minutes} min ago`
+
+  const hours   = Math.floor(minutes / 60)
+  if (hours < 24)     return `${hours}h ago`
+
+  const days    = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+
+// ── buildCsv ──────────────────────────────────────────────────
+// Joins the three data tables by activityId into a single
+// per-activity row, then serialises to CSV.
+//
+// Why one merged CSV instead of three separate files:
+//   Board-level use case is "give me one spreadsheet I can sort
+//   and filter". Three separate files mean three vlookups on
+//   their end. Doing the join here makes the export immediately
+//   useful in Excel / Google Sheets.
+//
+// Keeping this as a plain function (not a hook, not a class)
+// because it's pure — same inputs → same string.
+function buildCsv(stats) {
+
+  if (!stats) return ''
+
+  const {
+    mostPopularActivities,
+    cancellationRates,
+  } = stats
+
+  // Index cancellation data by activityId so we can attach
+  // it to each popular-activity row in O(n) total instead of
+  // a nested find() (which would be O(n²) on each export).
+  const cancellationByActivityId = new Map()
+
+  for (const row of cancellationRates.perActivity) {
+    cancellationByActivityId.set(row.activityId, row)
+  }
+
+  // CSV header. Keep column names short and snake-case-ish so
+  // they're easy to reference in spreadsheet formulas.
+  const header = [
+    'Activity',
+    'Participants',
+    'Favorites',
+    'Total Schedules',
+    'Cancelled Schedules',
+    'Cancellation Rate (%)',
+  ]
+
+  // Per-row values. `mostPopularActivities` is already pre-sorted
+  // by the backend (participants desc, then favorites desc) so
+  // the CSV mirrors what the user sees on the dashboard.
+  const rows = mostPopularActivities.map(activity => {
+
+    const cancellation =
+      cancellationByActivityId.get(activity.activityId)
+
+    return [
+      activity.activityName,
+      activity.participantCount,
+      activity.favoriteCount,
+      cancellation?.totalSchedules     ?? 0,
+      cancellation?.cancelledSchedules ?? 0,
+
+      // toFixed(1) keeps the column tidy in Excel — "12.5"
+      // rather than "12.4999999...". Multiply by 100 here
+      // because the backend returns a 0..1 ratio.
+      cancellation
+        ? (cancellation.cancellationRate * 100).toFixed(1)
+        : '0.0',
+    ]
+  })
+
+  // Escape any cells that contain a comma, quote, or newline by
+  // wrapping in double quotes and doubling any embedded quotes.
+  // Standard CSV rule — without this an activity name with a
+  // comma in it (e.g. "Yoga, Beginner") would break the columns.
+  function escapeCell(cell) {
+
+    const str = String(cell ?? '')
+
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`
+    }
+
+    return str
+  }
+
+  return [header, ...rows]
+    .map(row => row.map(escapeCell).join(','))
+    .join('\n')
+}
+
+
+// ── downloadCsv ───────────────────────────────────────────────
+// Browser-side download trigger. Creates a Blob URL, attaches it
+// to an off-DOM anchor, and clicks it. Standard technique — no
+// extra deps. Falls back gracefully if the browser doesn't
+// support the download attribute (the file just opens in a new
+// tab, still usable).
+function downloadCsv(csv, filename) {
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url  = URL.createObjectURL(blob)
+
+  const link = document.createElement('a')
+  link.href     = url
+  link.download = filename
+
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+
+  // Free the blob URL — browsers don't auto-revoke these.
+  URL.revokeObjectURL(url)
+}
+
+
+// ── KpiTile ───────────────────────────────────────────────────
+// Small presentational helper for the 4 metric cards across the
+// top of the page. Extracted to keep the main JSX block readable
+// — without this the tile section would be ~60 lines of repeated
+// markup. Inlined render-wise, no separate file needed since
+// nothing else uses it.
+function KpiTile({ label, value, hint }) {
+  return (
+    <Card padding="md" shadow="sm">
+
+      <p
+        style={{
+          fontSize:      '0.85rem',
+          color:         COLOR_TEXT_MUTED,
+          marginBottom:  '8px',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        {label}
+      </p>
+
+      <p
+        style={{
+          fontSize:   '2rem',
+          fontWeight: 700,
+          lineHeight: 1.1,
+        }}
+      >
+        {value}
+      </p>
+
+      {/* Optional secondary line under the big number — used to
+          show e.g. "out of 142 schedules" under the cancellation
+          rate so the percentage has context. */}
+      {hint && (
+        <p
+          style={{
+            fontSize:    '0.8rem',
+            color:       COLOR_TEXT_MUTED,
+            marginTop:   '4px',
+          }}
+        >
+          {hint}
+        </p>
+      )}
+
+    </Card>
+  )
+}
+
+
+// ── ChartCard ─────────────────────────────────────────────────
+// Wrapper for each chart so the title + description treatment
+// stays identical across all three. Children is the actual
+// recharts <ResponsiveContainer>.
+function ChartCard({ title, description, children }) {
+  return (
+    <Card
+      padding="lg"
+      shadow="sm"
+      style={{ marginBottom: '24px' }}
+    >
+      <h2
+        style={{
+          fontSize:     '1.2rem',
+          marginBottom: '4px',
+        }}
+      >
+        {title}
+      </h2>
+
+      <p
+        style={{
+          fontSize:     '0.9rem',
+          color:        COLOR_TEXT_MUTED,
+          marginBottom: '20px',
+        }}
+      >
+        {description}
+      </p>
+
+      {children}
+    </Card>
+  )
+}
+
+
+// ── StatisticsPage ────────────────────────────────────────────
+export default function StatisticsPage() {
+
+  // ── Auth ────────────────────────────────────────────────────
+  const { token } = useAuth()
+  // No useNavigate / user lookup needed here — the route gate in
+  // App.jsx already guarantees we have an ADMIN at this point.
+
+  // ── State ───────────────────────────────────────────────────
+  const [stats,       setStats]       = useState(null)
+  const [loading,     setLoading]     = useState(true)
+  const [refreshing,  setRefreshing]  = useState(false)
+  const [error,       setError]       = useState(null)
+
+  // When the most recent successful fetch landed. Drives the
+  // "Last updated X ago" label.
+  const [lastUpdated, setLastUpdated] = useState(null)
+
+  // Tick state used purely to force a re-render every 30s so the
+  // relative-time label stays fresh even when no data changes.
+  // We don't actually read `nowTick` — its identity flipping is
+  // the whole point.
+  // eslint-disable-next-line no-unused-vars
+  const [nowTick,     setNowTick]     = useState(0)
+
+
+  // ── Fetch ───────────────────────────────────────────────────
+  // Single loader function — called once on mount and again
+  // every time the user clicks "Refresh". Two booleans separate
+  // the initial load (shows skeleton) from a manual refresh
+  // (keeps the existing chart on screen, just dims the buttons).
+
+  async function loadStatistics({ isRefresh = false } = {}) {
+
+    if (!token) return
+
+    if (isRefresh) {
+      setRefreshing(true)
+    } else {
+      setLoading(true)
+    }
+
+    setError(null)
+
+    try {
+
+      const { data } = await fetchAdminStatistics(token)
+
+      setStats(data)
+      setLastUpdated(new Date())
+
+    } catch (err) {
+
+      if (err instanceof AuthExpiredError) {
+
+        // Token rejected — fall through to the error card.
+        // A real app would clear the session here via a hook
+        // like useAuthExpiredHandler(); leaving that for the
+        // existing global handler to pick up on the next
+        // protected route the user lands on.
+        setError('Your session has expired. Please log in again.')
+
+      } else {
+
+        console.error('Failed to load admin statistics:', err)
+        setError('Failed to load statistics.')
+      }
+
+    } finally {
+
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }
+
+
+  // Initial load on mount. Deliberate empty-ish dep array
+  // (token only) — refresh is user-initiated, not effect-driven,
+  // to avoid loops where setLastUpdated → re-run effect.
+  useEffect(() => {
+
+    loadStatistics()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token])
+
+
+  // Tick every 30s to update the relative-time label.
+  // Cleared on unmount — important, otherwise a user navigating
+  // away keeps the timer alive in the background.
+  useEffect(() => {
+
+    const interval = setInterval(() => {
+      setNowTick(t => t + 1)
+    }, 30_000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+
+  // ── Derived data ────────────────────────────────────────────
+  // useMemo so we don't recompute the chart-shaped arrays on
+  // every render — they only change when `stats` changes.
+
+  const popularChartData = useMemo(() => {
+
+    if (!stats) return []
+
+    // Top 10 only. Backend pre-sorts the full list; we cap it
+    // here for chart readability — more than ~10 horizontal bars
+    // turns the y-axis labels into a wall of text.
+    return stats.mostPopularActivities
+      .slice(0, 10)
+      .map(activity => ({
+        name:         activity.activityName,
+        Participants: activity.participantCount,
+        Favorites:    activity.favoriteCount,
+      }))
+
+  }, [stats])
+
+
+  const participantsChartData = useMemo(() => {
+
+    if (!stats) return []
+
+    // Sort descending so the bar chart reads left → right by
+    // popularity. Backend doesn't pre-sort `totalParticipants
+    // PerActivity` (that ordering is only applied to
+    // `mostPopularActivities`).
+    return [...stats.totalParticipantsPerActivity]
+      .sort((a, b) => b.participantCount - a.participantCount)
+      .map(activity => ({
+        name:         activity.activityName,
+        Participants: activity.participantCount,
+      }))
+
+  }, [stats])
+
+
+  const cancellationChartData = useMemo(() => {
+
+    if (!stats) return []
+
+    // Filter out activities with zero schedules — a "0%
+    // cancellation rate from 0 schedules" row is misleading
+    // (you can't cancel what was never scheduled). Sort
+    // descending to put the worst offenders at the top.
+    return stats.cancellationRates.perActivity
+      .filter(row => row.totalSchedules > 0)
+      .sort((a, b) => b.cancellationRate - a.cancellationRate)
+      .map(row => ({
+        name:               row.activityName,
+        'Cancellation %':   Number(
+                              (row.cancellationRate * 100).toFixed(1)
+                            ),
+        totalSchedules:     row.totalSchedules,
+        cancelledSchedules: row.cancelledSchedules,
+      }))
+
+  }, [stats])
+
+
+  // ── KPI tile values ─────────────────────────────────────────
+  // useMemo to keep the totals stable across re-renders that
+  // aren't related to a data change (e.g. the 30s timer tick).
+
+  const kpis = useMemo(() => {
+
+    if (!stats) return null
+
+    const totalParticipants = stats
+      .totalParticipantsPerActivity
+      .reduce((sum, row) => sum + row.participantCount, 0)
+
+    const totalFavorites = stats
+      .mostPopularActivities
+      .reduce((sum, row) => sum + row.favoriteCount, 0)
+
+    return {
+      totalActivities:    stats.totalParticipantsPerActivity.length,
+      totalParticipants,
+      totalFavorites,
+      overallCancellation:
+        (stats.cancellationRates.overallRate * 100).toFixed(1),
+      totalSchedules:
+        stats.cancellationRates.totalSchedules,
+      cancelledSchedules:
+        stats.cancellationRates.cancelledSchedules,
+    }
+
+  }, [stats])
+
+
+  // ── Handlers ────────────────────────────────────────────────
+  function handleRefresh() {
+    loadStatistics({ isRefresh: true })
+  }
+
+  function handleExportCsv() {
+
+    const csv      = buildCsv(stats)
+    const stamp    = new Date().toISOString().slice(0, 10)
+    // ISO date prefix on the filename so multiple exports on
+    // the same day don't all collide as "hkif-statistics.csv".
+    // Format: hkif-statistics-2026-05-23.csv
+    const filename = `hkif-statistics-${stamp}.csv`
+
+    downloadCsv(csv, filename)
+  }
+
+
+  // ── Loading state ───────────────────────────────────────────
+  // Renders the full page shape as shimmering placeholders so
+  // the layout doesn't jump when /api/admin/statistics resolves.
+  // Same pattern as ProfilePage's loading state.
+  if (loading) {
+    return <StatisticsSkeleton />
+  }
+
+
+  // ── Error state ─────────────────────────────────────────────
+  // Plain card with a retry button. Matches the simple
+  // error treatment on /profile.
+  if (error) {
+    return (
+      <div
+        style={{
+          padding:   'var(--space-6)',
+          maxWidth:  '1100px',
+          margin:    '0 auto',
+        }}
+      >
+        <Card padding="lg">
+
+          <p style={{ marginBottom: '16px' }}>{error}</p>
+
+          {/* Retry only makes sense for non-auth errors, but
+              we offer it anyway — if it really was a token
+              issue, the next attempt will just re-fail with
+              the same message, no harm done. */}
+          <Button
+            variant="primary"
+            onClick={() => loadStatistics()}
+          >
+            Try Again
+          </Button>
+
+        </Card>
+      </div>
+    )
+  }
+
+
+  // ── Render ──────────────────────────────────────────────────
+  return (
+
+    <div
+      style={{
+        padding:  'var(--space-6)',
+        maxWidth: '1100px',
+        margin:   '0 auto',
+      }}
+    >
+
+      {/* ── Header row ──────────────────────────────────────── */}
+      <div
+        style={{
+          display:        'flex',
+          justifyContent: 'space-between',
+          alignItems:     'center',
+          marginBottom:   '24px',
+          flexWrap:       'wrap',
+          gap:            '12px',
+        }}
+      >
+
+        <div>
+
+          <h1
+            style={{
+              fontSize:     '2rem',
+              marginBottom: '4px',
+            }}
+          >
+            Statistics Dashboard
+          </h1>
+
+          {/* Live relative-time label. Re-renders every 30s
+              via the nowTick effect above. */}
+          <p
+            style={{
+              fontSize: '0.9rem',
+              color:    COLOR_TEXT_MUTED,
+            }}
+          >
+            Last updated{' '}
+            <strong>{relativeTimeFrom(lastUpdated)}</strong>
+            {lastUpdated && (
+              <>
+                {' '}
+                · {lastUpdated.toLocaleTimeString()}
+              </>
+            )}
+          </p>
+
+        </div>
+
+        {/* Action buttons. Disabled while refreshing so the
+            user can't double-click and queue two requests. */}
+        <div
+          style={{
+            display:  'flex',
+            gap:      '8px',
+            flexWrap: 'wrap',
+          }}
+        >
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </Button>
+
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleExportCsv}
+          >
+            Export CSV
+          </Button>
+
+        </div>
+
+      </div>
+
+
+      {/* ── KPI tiles ───────────────────────────────────────── */}
+      <div
+        style={{
+          display:             'grid',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(180px, 1fr))',
+          gap:           '16px',
+          marginBottom:  '32px',
+        }}
+      >
+
+        <KpiTile
+          label="Activities"
+          value={kpis.totalActivities}
+        />
+
+        <KpiTile
+          label="Total Participants"
+          value={kpis.totalParticipants}
+        />
+
+        <KpiTile
+          label="Total Favorites"
+          value={kpis.totalFavorites}
+        />
+
+        <KpiTile
+          label="Cancellation Rate"
+          value={`${kpis.overallCancellation}%`}
+          hint={
+            `${kpis.cancelledSchedules} of ` +
+            `${kpis.totalSchedules} schedules`
+          }
+        />
+
+      </div>
+
+
+      {/* ── Chart 1: Most Popular Activities ─────────────────
+          Horizontal grouped bar chart — participants vs
+          favorites side-by-side per activity, top 10 only.
+          Horizontal layout lets long activity names sit on the
+          y-axis without rotating. */}
+      <ChartCard
+        title="Most Popular Activities"
+        description={
+          'Top 10 activities by participation, with favorites' +
+          ' shown for comparison.'
+        }
+      >
+
+        {popularChartData.length === 0 ? (
+
+          <p
+            style={{
+              color:     COLOR_TEXT_MUTED,
+              padding:   '40px 0',
+              textAlign: 'center',
+            }}
+          >
+            No activity data yet.
+          </p>
+
+        ) : (
+
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart
+              data={popularChartData}
+              layout="vertical"
+              margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
+            >
+
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={COLOR_BORDER}
+              />
+
+              {/* For layout="vertical", X is the numeric axis
+                  and Y holds the category labels. */}
+              <XAxis
+                type="number"
+                stroke={COLOR_TEXT_MUTED}
+              />
+
+              <YAxis
+                dataKey="name"
+                type="category"
+                stroke={COLOR_TEXT_MUTED}
+                width={140}
+              />
+
+              <Tooltip />
+              <Legend />
+
+              <Bar
+                dataKey="Participants"
+                fill={COLOR_PRIMARY}
+                radius={[0, 4, 4, 0]}
+              />
+
+              <Bar
+                dataKey="Favorites"
+                fill={COLOR_PRIMARY_MID}
+                radius={[0, 4, 4, 0]}
+              />
+
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+
+      </ChartCard>
+
+
+      {/* ── Chart 2: Participants per Activity ───────────────
+          Standard vertical bar chart of all activities sorted
+          by participant count. Complements chart 1 by showing
+          the long tail — chart 1 only shows top 10. */}
+      <ChartCard
+        title="Participants per Activity"
+        description={
+          'Total participant count across all schedules for' +
+          ' each activity.'
+        }
+      >
+
+        {participantsChartData.length === 0 ? (
+
+          <p
+            style={{
+              color:     COLOR_TEXT_MUTED,
+              padding:   '40px 0',
+              textAlign: 'center',
+            }}
+          >
+            No participation data yet.
+          </p>
+
+        ) : (
+
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart
+              data={participantsChartData}
+              margin={{ top: 8, right: 24, left: 8, bottom: 48 }}
+            >
+
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={COLOR_BORDER}
+              />
+
+              {/* Rotated labels because activity names tend to
+                  be long enough that horizontal labels would
+                  overlap. -25° is a good compromise — readable
+                  without taking too much vertical space. */}
+              <XAxis
+                dataKey="name"
+                stroke={COLOR_TEXT_MUTED}
+                angle={-25}
+                textAnchor="end"
+                height={60}
+                interval={0}
+              />
+
+              <YAxis stroke={COLOR_TEXT_MUTED} />
+
+              <Tooltip />
+
+              <Bar
+                dataKey="Participants"
+                fill={COLOR_PRIMARY}
+                radius={[4, 4, 0, 0]}
+              />
+
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+
+      </ChartCard>
+
+
+      {/* ── Chart 3: Cancellation Rate ───────────────────────
+          Horizontal bar chart. Bars are coloured red to signal
+          "the higher the bar, the bigger the problem" — using
+          the danger token instead of the primary green. */}
+      <ChartCard
+        title="Cancellation Rate per Activity"
+        description={
+          'Percentage of cancelled schedules per activity.' +
+          ' Sorted highest → lowest. Activities with no' +
+          ' schedules are hidden.'
+        }
+      >
+
+        {cancellationChartData.length === 0 ? (
+
+          <p
+            style={{
+              color:     COLOR_TEXT_MUTED,
+              padding:   '40px 0',
+              textAlign: 'center',
+            }}
+          >
+            No schedule data yet.
+          </p>
+
+        ) : (
+
+          <ResponsiveContainer width="100%" height={360}>
+            <BarChart
+              data={cancellationChartData}
+              layout="vertical"
+              margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
+            >
+
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={COLOR_BORDER}
+              />
+
+              <XAxis
+                type="number"
+                stroke={COLOR_TEXT_MUTED}
+                domain={[0, 100]}
+                unit="%"
+              />
+
+              <YAxis
+                dataKey="name"
+                type="category"
+                stroke={COLOR_TEXT_MUTED}
+                width={140}
+              />
+
+              <Tooltip
+                formatter={(value) => `${value}%`}
+              />
+
+              {/* Single Bar with a Cell for each row so each bar
+                  can be coloured identically with the danger
+                  token. We could just pass `fill` on the Bar,
+                  but using Cells leaves the door open to e.g.
+                  highlighting rows above a threshold later. */}
+              <Bar
+                dataKey="Cancellation %"
+                radius={[0, 4, 4, 0]}
+              >
+                {cancellationChartData.map((_, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLOR_DANGER}
+                  />
+                ))}
+              </Bar>
+
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+
+      </ChartCard>
+
+    </div>
+  )
+}

--- a/client/src/services/AdminStatisticsService.js
+++ b/client/src/services/AdminStatisticsService.js
@@ -1,0 +1,61 @@
+// All API calls for the admin statistics dashboard live here.
+// StatisticsPage imports these — nothing else should call them directly.
+//
+// Why a dedicated service file:
+//   Matches the FavoritesService / ProfileService / ManageActivitiesService
+//   pattern already used elsewhere — pages call named service functions,
+//   services own fetch() and error translation. Keeps page components
+//   declarative and easy to read in code review.
+
+import { API_BASE_URL } from './apiConfig.js'
+import { AuthExpiredError } from './AuthExpiredError.js'
+// AuthExpiredError signals "the JWT got rejected" specifically —
+// the page can react with logout + redirect to /login instead of
+// treating it like any other API failure.
+
+const BASE = `${API_BASE_URL}/api/admin/statistics`
+
+// ── fetchAdminStatistics ──────────────────────────────────────
+// GET /api/admin/statistics
+//
+// Returns the full JSON body:
+//   {
+//     status: 'success',
+//     data: {
+//       totalParticipantsPerActivity: [{ activityId, activityName, participantCount }],
+//       mostPopularActivities:        [{ activityId, activityName, participantCount, favoriteCount }],
+//       cancellationRates: {
+//         overallRate, totalSchedules, cancelledSchedules,
+//         perActivity: [{ activityId, activityName, totalSchedules, cancelledSchedules, cancellationRate }]
+//       }
+//     }
+//   }
+//
+// Auth note:
+//   Endpoint is gated server-side via restrictToMinRole(ADMIN).
+//   A non-ADMIN token will return 403, not 401 — we surface that
+//   as a generic error rather than AuthExpiredError because the
+//   token is still valid, the user just doesn't have permission.
+//   In practice the frontend route gate (App.jsx) prevents anyone
+//   except ADMIN from reaching this code path at all.
+export async function fetchAdminStatistics(token) {
+
+  const response = await fetch(BASE, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  // 401 = JWT expired/invalid → tear down the session.
+  // Checked BEFORE the generic !response.ok so the page can
+  // route into logout + redirect via useAuthExpiredHandler.
+  if (response.status === 401) {
+    throw new AuthExpiredError()
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch admin statistics')
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## what was included in this pr
- new `/admin/statistics` page — admin-only dashboard with KPIs and recharts charts
- pulls aggregate data from `GET /api/admin/statistics` (already existed on the backend, was unexposed)
- "📊 Open Statistics" button added to the hero card on `/profile`, only visible to ADMIN
- full skeleton + error card loading states matching the pattern from `/profile`

- closes #85 —

## files touched
- `client/package.json` + `client/package-lock.json` — added `recharts` (sorry for the noisy lockfile diff 🙃)
- `client/src/services/AdminStatisticsService.js` — new, wraps `GET /api/admin/statistics` with token + `AuthExpiredError` handling (same pattern as `FavoritesService`)
- `client/src/components/skeletons/StatisticsSkeleton.jsx` — new, mirrors the real page layout so nothing jumps when data lands
- `client/src/pages/StatisticsPage.jsx` — new, the actual dashboard (KPIs + 3 charts + CSV export + refresh + last-updated stamp)
- `client/src/App.jsx` — new protected route `/admin/statistics` gated to `[ROLES.ADMIN]`, also pulls `ROLES` from `constants/roles.js`
- `client/src/pages/ProfilePage.jsx` — imports `ROLES`, adds `isAdmin` flag, renders the "Open Statistics" button inside the hero card

## what's on the page
- **KPI tiles** — Activities, Total Participants, Total Favorites, Cancellation Rate (with "X of Y schedules" hint)
- **Most Popular Activities** — horizontal grouped bar chart, top 10, shows participants vs favorites side by side
- **Participants per Activity** — vertical bar chart sorted descending, includes the long tail
- **Cancellation Rate per Activity** — horizontal red bar chart, hides activities with no schedules, sorted worst → best
- **Refresh button** — manually re-fetches without unmounting the page (existing charts stay visible while refreshing)
- **Last updated X ago** — live label that ticks every 30s, plus exact timestamp for the precise folks
- **Export CSV** — single merged CSV joining all three tables by activityId. Filename includes today's date so multiple exports don't collide

## ADMIN-only and not MANAGER_ROLES
The backend endpoint is `restrictToMinRole(ADMIN)`. If we let BOARD_MEMBER through on the frontend they'd just get a 403 → bad UX. Easier to keep the frontend gate strict and matching the backend. If we ever want to widen access, we change both sides at once.


## how to test
1. log in as ADMIN (`user1@example.com` / `user1pass` from seed)
2. go to `/profile` → "📊 Open Statistics" should be on the hero card → click it
3. should land on `/admin/statistics`, see skeleton briefly, then KPIs + 3 charts
4. wait ~40s → "Last updated" label should tick from "just now" → "30s ago" → "1 min ago"
5. click Refresh → button shows "Refreshing…", timestamp resets to "just now", charts stay visible (no full skeleton flash)
6. click Export CSV → downloads `hkif-statistics-YYYY-MM-DD.csv` with 6 columns
7. log out, log in as LEADER (`user2@example.com` / `user2pass`)
   - no stats button on `/profile`
   - typing `/admin/statistics` in the URL bar → bounced to `/`
8. same checks as MEMBER (`user6@example.com` / `user6pass`)
9. stop the backend → click Refresh → error card with "Try Again" appears → restart backend → "Try Again" recovers cleanly
10. devtools → 375px width → KPI tiles stack, header buttons wrap, no horizontal scrolling

## notes for review
- `recharts` is the only new dependency — lockfile diff is just that one install
- one `// eslint-disable-next-line no-unused-vars` on the `nowTick` state — it's intentional, the state value isn't read but flipping it forces a re-render so the relative-time label stays fresh. happy to refactor to a different approach if anyone has a cleaner suggestion
- CSV export is one merged file (not three) — easier to use in spreadsheets, but let me know if you'd rather have three separate exports
- the 30s tick interval is cleared on unmount in the effect — checked, no leak
- backend role middleware is still the real enforcement layer; the frontend gates just prevent doomed fetches and dead-end "no permission" screens