### PR TITLE
refactor — statistics page 

### DIFF
--- a/client/src/components/statistics/ChartCard.jsx
+++ b/client/src/components/statistics/ChartCard.jsx
@@ -1,0 +1,56 @@
+// ChartCard — wraps a recharts chart in a consistent card shell
+// with a title and description.
+//
+// Why this lives in its own file:
+//   All three statistics charts use the exact same title +
+//   description + spacing treatment. Inlining the markup in each
+//   chart component would mean any visual tweak (e.g. tightening
+//   the description margin) needs to be made in three places.
+//
+// Layout assumptions:
+//   - children is the chart itself (a recharts <ResponsiveContainer>
+//     or an empty-state <p>)
+//   - card padding="lg" matches the existing /profile cards so the
+//     statistics page feels visually consistent with profile
+
+import React from 'react'
+import Card from '../ui/Card.jsx'
+import { CHART_COLOR_TEXT_MUTED } from './chartTokens.js'
+
+export default function ChartCard({
+  title,
+  description,
+  children,
+}) {
+  return (
+
+    <Card
+      padding="lg"
+      shadow="sm"
+      style={{ marginBottom: '24px' }}
+    >
+
+      <h2
+        style={{
+          fontSize:     '1.2rem',
+          marginBottom: '4px',
+        }}
+      >
+        {title}
+      </h2>
+
+      <p
+        style={{
+          fontSize:     '0.9rem',
+          color:        CHART_COLOR_TEXT_MUTED,
+          marginBottom: '20px',
+        }}
+      >
+        {description}
+      </p>
+
+      {children}
+
+    </Card>
+  )
+}

--- a/client/src/components/statistics/StatisticsCancellationRateChart.jsx
+++ b/client/src/components/statistics/StatisticsCancellationRateChart.jsx
@@ -1,0 +1,133 @@
+// StatisticsCancellationRateChart — horizontal red bar chart
+// showing cancellation rate (%) per activity, sorted worst-first.
+//
+// Red bars (danger token) signal "higher = bigger problem" so the
+// chart reads at a glance without needing to interpret the
+// numbers — the worst offenders stand out by color alone.
+
+import React, { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+
+import ChartCard from './ChartCard.jsx'
+import {
+  CHART_COLOR_BAR_DANGER,
+  CHART_COLOR_TEXT_MUTED,
+  CHART_COLOR_GRID,
+} from './chartTokens.js'
+
+
+export default function StatisticsCancellationRateChart({
+  perActivity,
+}) {
+
+  const chartData = useMemo(() => {
+
+    if (!perActivity) return []
+
+    // Filter out activities with zero schedules — a "0%
+    // cancellation rate from 0 schedules" row is misleading
+    // (you can't cancel what was never scheduled). Sort
+    // descending to put the worst offenders at the top.
+    return perActivity
+      .filter(row => row.totalSchedules > 0)
+      .sort((a, b) => b.cancellationRate - a.cancellationRate)
+      .map(row => ({
+        name:               row.activityName,
+        'Cancellation %':   Number(
+                              (row.cancellationRate * 100).toFixed(1)
+                            ),
+        totalSchedules:     row.totalSchedules,
+        cancelledSchedules: row.cancelledSchedules,
+      }))
+
+  }, [perActivity])
+
+
+  return (
+
+    <ChartCard
+      title="Cancellation Rate per Activity"
+      description={
+        'Percentage of cancelled schedules per activity.' +
+        ' Sorted highest → lowest. Activities with no' +
+        ' schedules are hidden.'
+      }
+    >
+
+      {chartData.length === 0 ? (
+
+        <p
+          style={{
+            color:     CHART_COLOR_TEXT_MUTED,
+            padding:   '40px 0',
+            textAlign: 'center',
+          }}
+        >
+          No schedule data yet.
+        </p>
+
+      ) : (
+
+        <ResponsiveContainer width="100%" height={360}>
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
+          >
+
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLOR_GRID}
+            />
+
+            <XAxis
+              type="number"
+              stroke={CHART_COLOR_TEXT_MUTED}
+              domain={[0, 100]}
+              unit="%"
+            />
+
+            <YAxis
+              dataKey="name"
+              type="category"
+              stroke={CHART_COLOR_TEXT_MUTED}
+              width={140}
+            />
+
+            <Tooltip
+              formatter={(value) => `${value}%`}
+            />
+
+            {/* Single Bar with a Cell for each row so each bar
+                can be coloured identically with the danger token.
+                We could just pass `fill` on the Bar, but using
+                Cells leaves the door open to e.g. highlighting
+                rows above a threshold later. */}
+            <Bar
+              dataKey="Cancellation %"
+              radius={[0, 4, 4, 0]}
+            >
+              {chartData.map((_, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={CHART_COLOR_BAR_DANGER}
+                />
+              ))}
+            </Bar>
+
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+
+    </ChartCard>
+  )
+}

--- a/client/src/components/statistics/StatisticsKpiTiles.jsx
+++ b/client/src/components/statistics/StatisticsKpiTiles.jsx
@@ -1,0 +1,146 @@
+// StatisticsKpiTiles — the four metric cards across the top of
+// the statistics dashboard.
+//
+// Receives the raw stats object from the container and computes
+// the four totals internally. Moving the calculation out of the
+// container keeps StatisticsPage focused on data fetching +
+// layout, and means the KPI logic lives next to the markup that
+// renders it.
+//
+// Why one component for all four tiles instead of four KpiTile
+// children:
+//   The grid container + responsive breakpoints are shared.
+//   Splitting per-tile would force the parent to know about
+//   grid layout for tiles specifically. Keeping the grid +
+//   tiles together makes this self-contained.
+
+import React, { useMemo } from 'react'
+import Card from '../ui/Card.jsx'
+import { CHART_COLOR_TEXT_MUTED } from './chartTokens.js'
+
+// ── KpiTile ───────────────────────────────────────────────────
+// Inlined here (not exported) because it's only ever used by the
+// four tiles in this file. If a second page ever needs the same
+// tile shape, promote it to its own file at that point.
+function KpiTile({ label, value, hint }) {
+  return (
+    <Card padding="md" shadow="sm">
+
+      <p
+        style={{
+          fontSize:      '0.85rem',
+          color:         CHART_COLOR_TEXT_MUTED,
+          marginBottom:  '8px',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        {label}
+      </p>
+
+      <p
+        style={{
+          fontSize:   '2rem',
+          fontWeight: 700,
+          lineHeight: 1.1,
+        }}
+      >
+        {value}
+      </p>
+
+      {/* Optional secondary line under the big number — used to
+          show e.g. "out of 142 schedules" under the cancellation
+          rate so the percentage has context. */}
+      {hint && (
+        <p
+          style={{
+            fontSize:  '0.8rem',
+            color:     CHART_COLOR_TEXT_MUTED,
+            marginTop: '4px',
+          }}
+        >
+          {hint}
+        </p>
+      )}
+
+    </Card>
+  )
+}
+
+
+// ── StatisticsKpiTiles ────────────────────────────────────────
+export default function StatisticsKpiTiles({ stats }) {
+
+  // useMemo because the totals are summed every render, and the
+  // result only changes when `stats` itself changes (which is
+  // every refresh, but not on every nowTick re-render).
+  const kpis = useMemo(() => {
+
+    if (!stats) return null
+
+    const totalParticipants = stats
+      .totalParticipantsPerActivity
+      .reduce((sum, row) => sum + row.participantCount, 0)
+
+    const totalFavorites = stats
+      .mostPopularActivities
+      .reduce((sum, row) => sum + row.favoriteCount, 0)
+
+    return {
+      totalActivities:    stats.totalParticipantsPerActivity.length,
+      totalParticipants,
+      totalFavorites,
+      overallCancellation:
+        (stats.cancellationRates.overallRate * 100).toFixed(1),
+      totalSchedules:
+        stats.cancellationRates.totalSchedules,
+      cancelledSchedules:
+        stats.cancellationRates.cancelledSchedules,
+    }
+
+  }, [stats])
+
+  // Defensive: container only renders this after stats loads,
+  // but the null guard means dev refreshes mid-render don't
+  // explode if stats is briefly missing.
+  if (!kpis) return null
+
+  return (
+
+    <div
+      style={{
+        display:             'grid',
+        gridTemplateColumns:
+          'repeat(auto-fit, minmax(180px, 1fr))',
+        gap:          '16px',
+        marginBottom: '32px',
+      }}
+    >
+
+      <KpiTile
+        label="Activities"
+        value={kpis.totalActivities}
+      />
+
+      <KpiTile
+        label="Total Participants"
+        value={kpis.totalParticipants}
+      />
+
+      <KpiTile
+        label="Total Favorites"
+        value={kpis.totalFavorites}
+      />
+
+      <KpiTile
+        label="Cancellation Rate"
+        value={`${kpis.overallCancellation}%`}
+        hint={
+          `${kpis.cancelledSchedules} of ` +
+          `${kpis.totalSchedules} schedules`
+        }
+      />
+
+    </div>
+  )
+}

--- a/client/src/components/statistics/StatisticsParticipantsPerActivityChart.jsx
+++ b/client/src/components/statistics/StatisticsParticipantsPerActivityChart.jsx
@@ -1,0 +1,111 @@
+// StatisticsParticipantsPerActivityChart — vertical bar chart
+// of every activity's total participant count, sorted descending.
+//
+// Complements the "Most Popular" chart by showing the long tail:
+// that chart caps at top 10, this one includes everything.
+
+import React, { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+import ChartCard from './ChartCard.jsx'
+import {
+  CHART_COLOR_BAR_PRIMARY,
+  CHART_COLOR_TEXT_MUTED,
+  CHART_COLOR_GRID,
+} from './chartTokens.js'
+
+
+export default function StatisticsParticipantsPerActivityChart({
+  totalParticipantsPerActivity,
+}) {
+
+  const chartData = useMemo(() => {
+
+    if (!totalParticipantsPerActivity) return []
+
+    // Sort descending so the bar chart reads left → right by
+    // popularity. Backend doesn't pre-sort this array (only
+    // mostPopularActivities is sorted server-side).
+    return [...totalParticipantsPerActivity]
+      .sort((a, b) => b.participantCount - a.participantCount)
+      .map(activity => ({
+        name:         activity.activityName,
+        Participants: activity.participantCount,
+      }))
+
+  }, [totalParticipantsPerActivity])
+
+
+  return (
+
+    <ChartCard
+      title="Participants per Activity"
+      description={
+        'Total participant count across all schedules for' +
+        ' each activity.'
+      }
+    >
+
+      {chartData.length === 0 ? (
+
+        <p
+          style={{
+            color:     CHART_COLOR_TEXT_MUTED,
+            padding:   '40px 0',
+            textAlign: 'center',
+          }}
+        >
+          No participation data yet.
+        </p>
+
+      ) : (
+
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart
+            data={chartData}
+            margin={{ top: 8, right: 24, left: 8, bottom: 48 }}
+          >
+
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLOR_GRID}
+            />
+
+            {/* Rotated labels because activity names tend to be
+                long enough that horizontal labels would overlap.
+                -25° is readable without taking too much vertical
+                space. */}
+            <XAxis
+              dataKey="name"
+              stroke={CHART_COLOR_TEXT_MUTED}
+              angle={-25}
+              textAnchor="end"
+              height={60}
+              interval={0}
+            />
+
+            <YAxis stroke={CHART_COLOR_TEXT_MUTED} />
+
+            <Tooltip />
+
+            <Bar
+              dataKey="Participants"
+              fill={CHART_COLOR_BAR_PRIMARY}
+              radius={[4, 4, 0, 0]}
+            />
+
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+
+    </ChartCard>
+  )
+}

--- a/client/src/components/statistics/StatisticsPopularActivitiesChart.jsx
+++ b/client/src/components/statistics/StatisticsPopularActivitiesChart.jsx
@@ -1,0 +1,128 @@
+// StatisticsPopularActivitiesChart — top 10 activities by
+// participation, with favorites shown side-by-side for comparison.
+//
+// Horizontal grouped bar chart. Horizontal layout lets long
+// activity names sit on the y-axis without rotating.
+//
+// Data shaping is done in here (not in the container) so this
+// component is self-contained — caller passes the raw
+// mostPopularActivities array, the component handles everything
+// else.
+
+import React, { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+
+import ChartCard from './ChartCard.jsx'
+import {
+  CHART_COLOR_BAR_PRIMARY,
+  CHART_COLOR_BAR_SECONDARY,
+  CHART_COLOR_TEXT_MUTED,
+  CHART_COLOR_GRID,
+} from './chartTokens.js'
+
+
+export default function StatisticsPopularActivitiesChart({
+  mostPopularActivities,
+}) {
+
+  // useMemo so we don't reshape the array on every nowTick render
+  // (every 30s). Only recomputes when the underlying data changes.
+  const chartData = useMemo(() => {
+
+    if (!mostPopularActivities) return []
+
+    // Top 10 only. Backend pre-sorts the full list; we cap it
+    // here for chart readability — more than ~10 horizontal bars
+    // turns the y-axis labels into a wall of text.
+    return mostPopularActivities
+      .slice(0, 10)
+      .map(activity => ({
+        name:         activity.activityName,
+        Participants: activity.participantCount,
+        Favorites:    activity.favoriteCount,
+      }))
+
+  }, [mostPopularActivities])
+
+
+  return (
+
+    <ChartCard
+      title="Most Popular Activities"
+      description={
+        'Top 10 activities by participation, with favorites' +
+        ' shown for comparison.'
+      }
+    >
+
+      {chartData.length === 0 ? (
+
+        <p
+          style={{
+            color:     CHART_COLOR_TEXT_MUTED,
+            padding:   '40px 0',
+            textAlign: 'center',
+          }}
+        >
+          No activity data yet.
+        </p>
+
+      ) : (
+
+        <ResponsiveContainer width="100%" height={400}>
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
+          >
+
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLOR_GRID}
+            />
+
+            {/* For layout="vertical", X is the numeric axis
+                and Y holds the category labels. */}
+            <XAxis
+              type="number"
+              stroke={CHART_COLOR_TEXT_MUTED}
+            />
+
+            <YAxis
+              dataKey="name"
+              type="category"
+              stroke={CHART_COLOR_TEXT_MUTED}
+              width={140}
+            />
+
+            <Tooltip />
+            <Legend />
+
+            <Bar
+              dataKey="Participants"
+              fill={CHART_COLOR_BAR_PRIMARY}
+              radius={[0, 4, 4, 0]}
+            />
+
+            <Bar
+              dataKey="Favorites"
+              fill={CHART_COLOR_BAR_SECONDARY}
+              radius={[0, 4, 4, 0]}
+            />
+
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+
+    </ChartCard>
+  )
+}

--- a/client/src/components/statistics/chartTokens.js
+++ b/client/src/components/statistics/chartTokens.js
@@ -1,0 +1,26 @@
+// Chart color tokens — single source of truth for the recharts
+// fills and strokes used across the statistics dashboard.
+//
+// Why this file exists:
+//   The three chart components all reference the same CSS custom
+//   properties for their bars, gridlines, and axis text. Duplicating
+//   the strings ('var(--color-primary)' etc.) across three files
+//   means three places to update if the design system changes.
+//
+//   Keeping them as named exports also gives the values a semantic
+//   label — `CHART_COLOR_BAR_PRIMARY` reads better than a raw CSS
+//   var string scattered through chart props.
+//
+// All values resolve to CSS custom properties already defined in
+// index.css — no new colors introduced here.
+
+export const CHART_COLOR_BAR_PRIMARY   = 'var(--color-primary)'
+export const CHART_COLOR_BAR_SECONDARY = 'var(--color-primary-mid)'
+export const CHART_COLOR_BAR_DANGER    = 'var(--color-danger)'
+
+// Used for axis labels and the "no data yet" empty-state text.
+export const CHART_COLOR_TEXT_MUTED    = 'var(--color-text-muted)'
+
+// CartesianGrid stroke — kept distinct from the muted text color
+// in case the grid ever wants a different (probably lighter) shade.
+export const CHART_COLOR_GRID          = 'var(--color-border)'

--- a/client/src/hooks/useIsAdmin.js
+++ b/client/src/hooks/useIsAdmin.js
@@ -1,0 +1,30 @@
+// useIsAdmin — single source of truth for "is the current user
+// an ADMIN?".
+//
+// Why a hook instead of inline checks:
+//   We had `user?.role === ROLES.ADMIN` duplicated in ProfilePage
+//   and (conceptually) StatisticsPage. Two places means two places
+//   to update if we ever change how ADMIN is identified — e.g. if
+//   we widen access to "ADMIN or SUPER_ADMIN" later, or move to a
+//   permission-flag model rather than a role string. Centralising
+//   in a hook means one edit instead of grepping the codebase.
+//
+// USAGE:
+//   const isAdmin = useIsAdmin()
+//   if (isAdmin) { ... }
+//
+// Returns false (not undefined) when there's no user, so callers
+// can use it directly in conditional rendering without optional
+// chaining clutter.
+//
+// Related role helpers live next to this file — if you need a
+// "useCanManage()" hook later for MANAGER_ROLES, follow the same
+// pattern.
+
+import { useAuth } from '../context/AuthContext.jsx'
+import { ROLES } from '../constants/roles.js'
+
+export function useIsAdmin() {
+  const { user } = useAuth()
+  return user?.role === ROLES.ADMIN
+}

--- a/client/src/hooks/useNowTick.js
+++ b/client/src/hooks/useNowTick.js
@@ -1,0 +1,49 @@
+// useNowTick — force a re-render every `intervalMs` milliseconds.
+//
+// Use case: components that display a *relative* time string like
+// "Last updated 2 min ago". The underlying timestamp doesn't change,
+// but the rendered text needs to age — without an external nudge,
+// React would never re-run the component and the label would stay
+// frozen at "just now" forever.
+//
+// USAGE:
+//   function StatisticsPage() {
+//     useNowTick(30_000)            // re-render every 30s
+//     return <p>Last updated {relativeTimeFrom(lastUpdated)}</p>
+//   }
+//
+// Why a hook (instead of an unused `nowTick` state in the page):
+//   The previous implementation kept a useState whose VALUE was never
+//   read — only the act of calling setNowTick() forced React to
+//   re-render. That triggered `no-unused-vars` and required an
+//   eslint-disable comment. Hiding the state inside a hook makes
+//   the intent obvious from the call site ("we want a tick") and
+//   removes the lint suppression from the page.
+//
+// Internally we still use useState, but we deliberately discard
+// the value with `[, setTick]` — the lint rule is happy because
+// it's the destructured slot that's empty, not an unused variable.
+
+import { useEffect, useState } from 'react'
+
+export function useNowTick(intervalMs = 30_000) {
+
+  // Empty first slot — we only need the setter to schedule
+  // re-renders. The current tick value isn't useful to anyone.
+  const [, setTick] = useState(0)
+
+  useEffect(() => {
+
+    const id = setInterval(() => {
+      // Functional update so we don't depend on a captured `tick`
+      // value. Lets us keep the dep array minimal.
+      setTick(t => t + 1)
+    }, intervalMs)
+
+    // Always clear on unmount — otherwise a user navigating away
+    // from /admin/statistics would leave a timer alive in the
+    // background, holding a closure reference to setTick forever.
+    return () => clearInterval(id)
+
+  }, [intervalMs])
+}

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -10,7 +10,8 @@ import {
 import {
   fetchManageableActivities,
 } from '../services/ManageActivitiesService.js'
-import { MANAGER_ROLES, ROLES } from '../constants/roles.js'
+import { MANAGER_ROLES } from '../constants/roles.js'
+import { useIsAdmin } from '../hooks/useIsAdmin.js'
 import Card from '../components/ui/Card.jsx'
 import Button from '../components/ui/Button.jsx'
 import Badge, {
@@ -36,9 +37,9 @@ export default function ProfilePage() {
 
   // Statistics dashboard is ADMIN-only — strictly narrower than
   // canManage because the backend endpoint is ADMIN-gated.
-  // Computed alongside canManage so both role checks live in
-  // the same spot and can't drift apart.
-  const isAdmin = user?.role === ROLES.ADMIN
+  // Sourced from the useIsAdmin hook so the role check stays
+  // consistent with any other page that asks the same question.
+  const isAdmin = useIsAdmin()
 
   // ── State ───────────────────────────────────────────────
 

--- a/client/src/pages/StatisticsPage.jsx
+++ b/client/src/pages/StatisticsPage.jsx
@@ -1,37 +1,25 @@
 // /admin/statistics
 //
-// Admin-only dashboard. Visualises aggregate data from
-// GET /api/admin/statistics:
-//   - 4 KPI tiles at the top
-//   - 3 recharts charts below (popular / participants / cancellation)
+// Admin-only dashboard. Thin container that:
+//   - fetches GET /api/admin/statistics
+//   - manages loading / refreshing / error state
+//   - lays out: header → KPI tiles → 3 charts
+//   - handles "Last updated X ago" stamp + manual refresh
+//   - handles CSV export
 //
-// Extra UX:
-//   - "Last updated X ago" stamp + manual refresh button
-//   - CSV export of the merged per-activity table
+// All chart rendering + data shaping lives in subcomponents under
+// components/statistics/ — this file should stay focused on data
+// flow and layout.
 //
 // Role gate is enforced in App.jsx via <ProtectedRoute requiredRoles=
 // {[ROLES.ADMIN]}>. The backend also restricts to ADMIN — the route
 // guard just prevents the page from mounting and firing a doomed
 // request for non-admins.
 
-import React, {
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-  Cell,
-} from 'recharts'
+import React, { useEffect, useState } from 'react'
 
 import { useAuth } from '../context/AuthContext.jsx'
+import { useNowTick } from '../hooks/useNowTick.js'
 import {
   fetchAdminStatistics,
 } from '../services/AdminStatisticsService.js'
@@ -42,18 +30,14 @@ import Button from '../components/ui/Button.jsx'
 import StatisticsSkeleton from
   '../components/skeletons/StatisticsSkeleton.jsx'
 
-
-// ── Chart color tokens ─────────────────────────────────────────
-// Pulled into named constants so the three charts stay visually
-// consistent and so future palette tweaks happen in one place
-// instead of scattered across <Bar fill="#..."> props.
-// All values are the CSS custom properties already defined in
-// index.css — no new colors introduced.
-const COLOR_PRIMARY     = 'var(--color-primary)'
-const COLOR_PRIMARY_MID = 'var(--color-primary-mid)'
-const COLOR_DANGER      = 'var(--color-danger)'
-const COLOR_TEXT_MUTED  = 'var(--color-text-muted)'
-const COLOR_BORDER      = 'var(--color-border)'
+import StatisticsKpiTiles from
+  '../components/statistics/StatisticsKpiTiles.jsx'
+import StatisticsPopularActivitiesChart from
+  '../components/statistics/StatisticsPopularActivitiesChart.jsx'
+import StatisticsParticipantsPerActivityChart from
+  '../components/statistics/StatisticsParticipantsPerActivityChart.jsx'
+import StatisticsCancellationRateChart from
+  '../components/statistics/StatisticsCancellationRateChart.jsx'
 
 
 // ── relativeTimeFrom ──────────────────────────────────────────
@@ -84,18 +68,42 @@ function relativeTimeFrom(date) {
 }
 
 
-// ── buildCsv ──────────────────────────────────────────────────
-// Joins the three data tables by activityId into a single
-// per-activity row, then serialises to CSV.
-//
-// Why one merged CSV instead of three separate files:
-//   Board-level use case is "give me one spreadsheet I can sort
-//   and filter". Three separate files mean three vlookups on
-//   their end. Doing the join here makes the export immediately
-//   useful in Excel / Google Sheets.
-//
-// Keeping this as a plain function (not a hook, not a class)
-// because it's pure — same inputs → same string.
+/**
+ * Build a CSV string from an admin statistics response.
+ *
+ * Joins the three data tables in the stats object by activityId
+ * into a single per-activity row, so the export is one merged
+ * spreadsheet rather than three files. Rows mirror the order of
+ * `mostPopularActivities`, which the backend pre-sorts by
+ * participants desc → favorites desc.
+ *
+ * The output has SIX columns in this exact order:
+ *
+ *   1. Activity              — activity name (string, escaped for
+ *                              commas / quotes / newlines)
+ *   2. Participants          — integer, from mostPopularActivities
+ *   3. Favorites             — integer, from mostPopularActivities
+ *   4. Total Schedules       — integer, from cancellationRates
+ *                              (0 if the activity has no schedule
+ *                              record at all)
+ *   5. Cancelled Schedules   — integer, from cancellationRates
+ *                              (0 if no schedule record)
+ *   6. Cancellation Rate (%) — number with 1 decimal place, e.g.
+ *                              "12.5". Computed as
+ *                              cancellationRate * 100, since the
+ *                              backend returns a 0..1 ratio.
+ *                              "0.0" if no schedule record.
+ *
+ * !!! Keep this column order + header text stable !!!
+ * Downstream users may have spreadsheets, pivot tables, or scripts
+ * that reference these columns by position or name. If you add a
+ * column, append it at the end. If you rename one, coordinate with
+ * whoever's consuming the export.
+ *
+ * @param   {object} stats — the `data` field from
+ *                           GET /api/admin/statistics
+ * @returns {string}         CSV text, or '' if stats is missing
+ */
 function buildCsv(stats) {
 
   if (!stats) return ''
@@ -105,17 +113,16 @@ function buildCsv(stats) {
     cancellationRates,
   } = stats
 
-  // Index cancellation data by activityId so we can attach
-  // it to each popular-activity row in O(n) total instead of
-  // a nested find() (which would be O(n²) on each export).
+  // Index cancellation data by activityId so we can attach it to
+  // each popular-activity row in O(n) total instead of a nested
+  // find() (which would be O(n²) on each export).
   const cancellationByActivityId = new Map()
 
   for (const row of cancellationRates.perActivity) {
     cancellationByActivityId.set(row.activityId, row)
   }
 
-  // CSV header. Keep column names short and snake-case-ish so
-  // they're easy to reference in spreadsheet formulas.
+  // Header text. See JSDoc above for the column contract.
   const header = [
     'Activity',
     'Participants',
@@ -125,9 +132,6 @@ function buildCsv(stats) {
     'Cancellation Rate (%)',
   ]
 
-  // Per-row values. `mostPopularActivities` is already pre-sorted
-  // by the backend (participants desc, then favorites desc) so
-  // the CSV mirrors what the user sees on the dashboard.
   const rows = mostPopularActivities.map(activity => {
 
     const cancellation =
@@ -194,101 +198,13 @@ function downloadCsv(csv, filename) {
 }
 
 
-// ── KpiTile ───────────────────────────────────────────────────
-// Small presentational helper for the 4 metric cards across the
-// top of the page. Extracted to keep the main JSX block readable
-// — without this the tile section would be ~60 lines of repeated
-// markup. Inlined render-wise, no separate file needed since
-// nothing else uses it.
-function KpiTile({ label, value, hint }) {
-  return (
-    <Card padding="md" shadow="sm">
-
-      <p
-        style={{
-          fontSize:      '0.85rem',
-          color:         COLOR_TEXT_MUTED,
-          marginBottom:  '8px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {label}
-      </p>
-
-      <p
-        style={{
-          fontSize:   '2rem',
-          fontWeight: 700,
-          lineHeight: 1.1,
-        }}
-      >
-        {value}
-      </p>
-
-      {/* Optional secondary line under the big number — used to
-          show e.g. "out of 142 schedules" under the cancellation
-          rate so the percentage has context. */}
-      {hint && (
-        <p
-          style={{
-            fontSize:    '0.8rem',
-            color:       COLOR_TEXT_MUTED,
-            marginTop:   '4px',
-          }}
-        >
-          {hint}
-        </p>
-      )}
-
-    </Card>
-  )
-}
-
-
-// ── ChartCard ─────────────────────────────────────────────────
-// Wrapper for each chart so the title + description treatment
-// stays identical across all three. Children is the actual
-// recharts <ResponsiveContainer>.
-function ChartCard({ title, description, children }) {
-  return (
-    <Card
-      padding="lg"
-      shadow="sm"
-      style={{ marginBottom: '24px' }}
-    >
-      <h2
-        style={{
-          fontSize:     '1.2rem',
-          marginBottom: '4px',
-        }}
-      >
-        {title}
-      </h2>
-
-      <p
-        style={{
-          fontSize:     '0.9rem',
-          color:        COLOR_TEXT_MUTED,
-          marginBottom: '20px',
-        }}
-      >
-        {description}
-      </p>
-
-      {children}
-    </Card>
-  )
-}
-
-
-// ── StatisticsPage ────────────────────────────────────────────
+// ── StatisticsPage (container) ────────────────────────────────
 export default function StatisticsPage() {
 
   // ── Auth ────────────────────────────────────────────────────
   const { token } = useAuth()
-  // No useNavigate / user lookup needed here — the route gate in
-  // App.jsx already guarantees we have an ADMIN at this point.
+  // No user lookup needed — the route gate in App.jsx already
+  // guarantees we have an ADMIN at this point.
 
   // ── State ───────────────────────────────────────────────────
   const [stats,       setStats]       = useState(null)
@@ -296,24 +212,21 @@ export default function StatisticsPage() {
   const [refreshing,  setRefreshing]  = useState(false)
   const [error,       setError]       = useState(null)
 
-  // When the most recent successful fetch landed. Drives the
+  // Timestamp of the most recent successful fetch. Drives the
   // "Last updated X ago" label.
   const [lastUpdated, setLastUpdated] = useState(null)
 
-  // Tick state used purely to force a re-render every 30s so the
-  // relative-time label stays fresh even when no data changes.
-  // We don't actually read `nowTick` — its identity flipping is
-  // the whole point.
-  // eslint-disable-next-line no-unused-vars
-  const [nowTick,     setNowTick]     = useState(0)
+  // Schedule a re-render every 30s so the relative-time label
+  // stays fresh even when no data changes. The hook hides the
+  // unused-state plumbing that used to require an eslint-disable.
+  useNowTick(30_000)
 
 
   // ── Fetch ───────────────────────────────────────────────────
-  // Single loader function — called once on mount and again
-  // every time the user clicks "Refresh". Two booleans separate
-  // the initial load (shows skeleton) from a manual refresh
-  // (keeps the existing chart on screen, just dims the buttons).
-
+  // Single loader function — called once on mount and again every
+  // time the user clicks "Refresh". Two booleans separate the
+  // initial load (shows skeleton) from a manual refresh (keeps
+  // the existing chart on screen, just dims the buttons).
   async function loadStatistics({ isRefresh = false } = {}) {
 
     if (!token) return
@@ -337,11 +250,10 @@ export default function StatisticsPage() {
 
       if (err instanceof AuthExpiredError) {
 
-        // Token rejected — fall through to the error card.
-        // A real app would clear the session here via a hook
-        // like useAuthExpiredHandler(); leaving that for the
-        // existing global handler to pick up on the next
-        // protected route the user lands on.
+        // Token rejected — fall through to the error card. A real
+        // app would clear the session here via useAuthExpired-
+        // Handler; leaving that to the existing global handler
+        // on the next protected route the user lands on.
         setError('Your session has expired. Please log in again.')
 
       } else {
@@ -358,122 +270,15 @@ export default function StatisticsPage() {
   }
 
 
-  // Initial load on mount. Deliberate empty-ish dep array
-  // (token only) — refresh is user-initiated, not effect-driven,
-  // to avoid loops where setLastUpdated → re-run effect.
+  // Initial load on mount. Deliberately narrow dep array (token
+  // only) — refresh is user-initiated, not effect-driven, to
+  // avoid loops where setLastUpdated → re-run effect.
   useEffect(() => {
 
     loadStatistics()
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token])
-
-
-  // Tick every 30s to update the relative-time label.
-  // Cleared on unmount — important, otherwise a user navigating
-  // away keeps the timer alive in the background.
-  useEffect(() => {
-
-    const interval = setInterval(() => {
-      setNowTick(t => t + 1)
-    }, 30_000)
-
-    return () => clearInterval(interval)
-  }, [])
-
-
-  // ── Derived data ────────────────────────────────────────────
-  // useMemo so we don't recompute the chart-shaped arrays on
-  // every render — they only change when `stats` changes.
-
-  const popularChartData = useMemo(() => {
-
-    if (!stats) return []
-
-    // Top 10 only. Backend pre-sorts the full list; we cap it
-    // here for chart readability — more than ~10 horizontal bars
-    // turns the y-axis labels into a wall of text.
-    return stats.mostPopularActivities
-      .slice(0, 10)
-      .map(activity => ({
-        name:         activity.activityName,
-        Participants: activity.participantCount,
-        Favorites:    activity.favoriteCount,
-      }))
-
-  }, [stats])
-
-
-  const participantsChartData = useMemo(() => {
-
-    if (!stats) return []
-
-    // Sort descending so the bar chart reads left → right by
-    // popularity. Backend doesn't pre-sort `totalParticipants
-    // PerActivity` (that ordering is only applied to
-    // `mostPopularActivities`).
-    return [...stats.totalParticipantsPerActivity]
-      .sort((a, b) => b.participantCount - a.participantCount)
-      .map(activity => ({
-        name:         activity.activityName,
-        Participants: activity.participantCount,
-      }))
-
-  }, [stats])
-
-
-  const cancellationChartData = useMemo(() => {
-
-    if (!stats) return []
-
-    // Filter out activities with zero schedules — a "0%
-    // cancellation rate from 0 schedules" row is misleading
-    // (you can't cancel what was never scheduled). Sort
-    // descending to put the worst offenders at the top.
-    return stats.cancellationRates.perActivity
-      .filter(row => row.totalSchedules > 0)
-      .sort((a, b) => b.cancellationRate - a.cancellationRate)
-      .map(row => ({
-        name:               row.activityName,
-        'Cancellation %':   Number(
-                              (row.cancellationRate * 100).toFixed(1)
-                            ),
-        totalSchedules:     row.totalSchedules,
-        cancelledSchedules: row.cancelledSchedules,
-      }))
-
-  }, [stats])
-
-
-  // ── KPI tile values ─────────────────────────────────────────
-  // useMemo to keep the totals stable across re-renders that
-  // aren't related to a data change (e.g. the 30s timer tick).
-
-  const kpis = useMemo(() => {
-
-    if (!stats) return null
-
-    const totalParticipants = stats
-      .totalParticipantsPerActivity
-      .reduce((sum, row) => sum + row.participantCount, 0)
-
-    const totalFavorites = stats
-      .mostPopularActivities
-      .reduce((sum, row) => sum + row.favoriteCount, 0)
-
-    return {
-      totalActivities:    stats.totalParticipantsPerActivity.length,
-      totalParticipants,
-      totalFavorites,
-      overallCancellation:
-        (stats.cancellationRates.overallRate * 100).toFixed(1),
-      totalSchedules:
-        stats.cancellationRates.totalSchedules,
-      cancelledSchedules:
-        stats.cancellationRates.cancelledSchedules,
-    }
-
-  }, [stats])
 
 
   // ── Handlers ────────────────────────────────────────────────
@@ -485,8 +290,8 @@ export default function StatisticsPage() {
 
     const csv      = buildCsv(stats)
     const stamp    = new Date().toISOString().slice(0, 10)
-    // ISO date prefix on the filename so multiple exports on
-    // the same day don't all collide as "hkif-statistics.csv".
+    // ISO date prefix on the filename so multiple exports on the
+    // same day don't all collide as "hkif-statistics.csv".
     // Format: hkif-statistics-2026-05-23.csv
     const filename = `hkif-statistics-${stamp}.csv`
 
@@ -495,34 +300,25 @@ export default function StatisticsPage() {
 
 
   // ── Loading state ───────────────────────────────────────────
-  // Renders the full page shape as shimmering placeholders so
-  // the layout doesn't jump when /api/admin/statistics resolves.
-  // Same pattern as ProfilePage's loading state.
   if (loading) {
     return <StatisticsSkeleton />
   }
 
 
   // ── Error state ─────────────────────────────────────────────
-  // Plain card with a retry button. Matches the simple
-  // error treatment on /profile.
   if (error) {
     return (
       <div
         style={{
-          padding:   'var(--space-6)',
-          maxWidth:  '1100px',
-          margin:    '0 auto',
+          padding:  'var(--space-6)',
+          maxWidth: '1100px',
+          margin:   '0 auto',
         }}
       >
         <Card padding="lg">
 
           <p style={{ marginBottom: '16px' }}>{error}</p>
 
-          {/* Retry only makes sense for non-auth errors, but
-              we offer it anyway — if it really was a token
-              issue, the next attempt will just re-fail with
-              the same message, no harm done. */}
           <Button
             variant="primary"
             onClick={() => loadStatistics()}
@@ -570,12 +366,12 @@ export default function StatisticsPage() {
             Statistics Dashboard
           </h1>
 
-          {/* Live relative-time label. Re-renders every 30s
-              via the nowTick effect above. */}
+          {/* Live relative-time label. Re-renders every 30s via
+              useNowTick above. */}
           <p
             style={{
               fontSize: '0.9rem',
-              color:    COLOR_TEXT_MUTED,
+              color:    'var(--color-text-muted)',
             }}
           >
             Last updated{' '}
@@ -590,8 +386,8 @@ export default function StatisticsPage() {
 
         </div>
 
-        {/* Action buttons. Disabled while refreshing so the
-            user can't double-click and queue two requests. */}
+        {/* Action buttons. Disabled while refreshing so the user
+            can't double-click and queue two requests. */}
         <div
           style={{
             display:  'flex',
@@ -623,264 +419,23 @@ export default function StatisticsPage() {
 
 
       {/* ── KPI tiles ───────────────────────────────────────── */}
-      <div
-        style={{
-          display:             'grid',
-          gridTemplateColumns:
-            'repeat(auto-fit, minmax(180px, 1fr))',
-          gap:           '16px',
-          marginBottom:  '32px',
-        }}
-      >
-
-        <KpiTile
-          label="Activities"
-          value={kpis.totalActivities}
-        />
-
-        <KpiTile
-          label="Total Participants"
-          value={kpis.totalParticipants}
-        />
-
-        <KpiTile
-          label="Total Favorites"
-          value={kpis.totalFavorites}
-        />
-
-        <KpiTile
-          label="Cancellation Rate"
-          value={`${kpis.overallCancellation}%`}
-          hint={
-            `${kpis.cancelledSchedules} of ` +
-            `${kpis.totalSchedules} schedules`
-          }
-        />
-
-      </div>
+      <StatisticsKpiTiles stats={stats} />
 
 
-      {/* ── Chart 1: Most Popular Activities ─────────────────
-          Horizontal grouped bar chart — participants vs
-          favorites side-by-side per activity, top 10 only.
-          Horizontal layout lets long activity names sit on the
-          y-axis without rotating. */}
-      <ChartCard
-        title="Most Popular Activities"
-        description={
-          'Top 10 activities by participation, with favorites' +
-          ' shown for comparison.'
+      {/* ── Charts ──────────────────────────────────────────── */}
+      <StatisticsPopularActivitiesChart
+        mostPopularActivities={stats.mostPopularActivities}
+      />
+
+      <StatisticsParticipantsPerActivityChart
+        totalParticipantsPerActivity={
+          stats.totalParticipantsPerActivity
         }
-      >
+      />
 
-        {popularChartData.length === 0 ? (
-
-          <p
-            style={{
-              color:     COLOR_TEXT_MUTED,
-              padding:   '40px 0',
-              textAlign: 'center',
-            }}
-          >
-            No activity data yet.
-          </p>
-
-        ) : (
-
-          <ResponsiveContainer width="100%" height={400}>
-            <BarChart
-              data={popularChartData}
-              layout="vertical"
-              margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
-            >
-
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke={COLOR_BORDER}
-              />
-
-              {/* For layout="vertical", X is the numeric axis
-                  and Y holds the category labels. */}
-              <XAxis
-                type="number"
-                stroke={COLOR_TEXT_MUTED}
-              />
-
-              <YAxis
-                dataKey="name"
-                type="category"
-                stroke={COLOR_TEXT_MUTED}
-                width={140}
-              />
-
-              <Tooltip />
-              <Legend />
-
-              <Bar
-                dataKey="Participants"
-                fill={COLOR_PRIMARY}
-                radius={[0, 4, 4, 0]}
-              />
-
-              <Bar
-                dataKey="Favorites"
-                fill={COLOR_PRIMARY_MID}
-                radius={[0, 4, 4, 0]}
-              />
-
-            </BarChart>
-          </ResponsiveContainer>
-        )}
-
-      </ChartCard>
-
-
-      {/* ── Chart 2: Participants per Activity ───────────────
-          Standard vertical bar chart of all activities sorted
-          by participant count. Complements chart 1 by showing
-          the long tail — chart 1 only shows top 10. */}
-      <ChartCard
-        title="Participants per Activity"
-        description={
-          'Total participant count across all schedules for' +
-          ' each activity.'
-        }
-      >
-
-        {participantsChartData.length === 0 ? (
-
-          <p
-            style={{
-              color:     COLOR_TEXT_MUTED,
-              padding:   '40px 0',
-              textAlign: 'center',
-            }}
-          >
-            No participation data yet.
-          </p>
-
-        ) : (
-
-          <ResponsiveContainer width="100%" height={320}>
-            <BarChart
-              data={participantsChartData}
-              margin={{ top: 8, right: 24, left: 8, bottom: 48 }}
-            >
-
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke={COLOR_BORDER}
-              />
-
-              {/* Rotated labels because activity names tend to
-                  be long enough that horizontal labels would
-                  overlap. -25° is a good compromise — readable
-                  without taking too much vertical space. */}
-              <XAxis
-                dataKey="name"
-                stroke={COLOR_TEXT_MUTED}
-                angle={-25}
-                textAnchor="end"
-                height={60}
-                interval={0}
-              />
-
-              <YAxis stroke={COLOR_TEXT_MUTED} />
-
-              <Tooltip />
-
-              <Bar
-                dataKey="Participants"
-                fill={COLOR_PRIMARY}
-                radius={[4, 4, 0, 0]}
-              />
-
-            </BarChart>
-          </ResponsiveContainer>
-        )}
-
-      </ChartCard>
-
-
-      {/* ── Chart 3: Cancellation Rate ───────────────────────
-          Horizontal bar chart. Bars are coloured red to signal
-          "the higher the bar, the bigger the problem" — using
-          the danger token instead of the primary green. */}
-      <ChartCard
-        title="Cancellation Rate per Activity"
-        description={
-          'Percentage of cancelled schedules per activity.' +
-          ' Sorted highest → lowest. Activities with no' +
-          ' schedules are hidden.'
-        }
-      >
-
-        {cancellationChartData.length === 0 ? (
-
-          <p
-            style={{
-              color:     COLOR_TEXT_MUTED,
-              padding:   '40px 0',
-              textAlign: 'center',
-            }}
-          >
-            No schedule data yet.
-          </p>
-
-        ) : (
-
-          <ResponsiveContainer width="100%" height={360}>
-            <BarChart
-              data={cancellationChartData}
-              layout="vertical"
-              margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
-            >
-
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke={COLOR_BORDER}
-              />
-
-              <XAxis
-                type="number"
-                stroke={COLOR_TEXT_MUTED}
-                domain={[0, 100]}
-                unit="%"
-              />
-
-              <YAxis
-                dataKey="name"
-                type="category"
-                stroke={COLOR_TEXT_MUTED}
-                width={140}
-              />
-
-              <Tooltip
-                formatter={(value) => `${value}%`}
-              />
-
-              {/* Single Bar with a Cell for each row so each bar
-                  can be coloured identically with the danger
-                  token. We could just pass `fill` on the Bar,
-                  but using Cells leaves the door open to e.g.
-                  highlighting rows above a threshold later. */}
-              <Bar
-                dataKey="Cancellation %"
-                radius={[0, 4, 4, 0]}
-              >
-                {cancellationChartData.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={COLOR_DANGER}
-                  />
-                ))}
-              </Bar>
-
-            </BarChart>
-          </ResponsiveContainer>
-        )}
-
-      </ChartCard>
+      <StatisticsCancellationRateChart
+        perActivity={stats.cancellationRates.perActivity}
+      />
 
     </div>
   )


### PR DESCRIPTION
## Wts included in this pr
follow-up refactor on `StatisticsPage.jsx` — no user-facing changes, just splitting the page into smaller pieces and cleaning up two code suggestionsthat came up in PR-85 review.

- split the chart rendering into three separate components (`StatisticsPopularActivitiesChart`, `StatisticsParticipantsPerActivityChart`, `StatisticsCancellationRateChart`), each in its own file
- extracted the KPI tiles into `StatisticsKpiTiles` and the chart card wrapper into `ChartCard`
- moved the chart color tokens into a shared `chartTokens.js`
- replaced the `nowTick` useState + `eslint-disable no-unused-vars` with a new `useNowTick` hook
- centralised the `user?.role === ROLES.ADMIN` check into a `useIsAdmin` hook
- added proper JSDoc on `buildCsv` documenting the column contract

this PR is purely the refactor to address all of that. no behavior changes, no new features.

## files touched
new files:
- `client/src/hooks/useNowTick.js` — forces a re-render every N ms for relative-time labels. internal `useState` is `[, setTick]` so there's nothing to lint-disable
- `client/src/hooks/useIsAdmin.js` — single source of truth for "is current user ADMIN", returns boolean
- `client/src/components/statistics/chartTokens.js` — named color constants (all CSS vars from index.css, no new colors)
- `client/src/components/statistics/ChartCard.jsx` — shared title + description + card shell
- `client/src/components/statistics/StatisticsKpiTiles.jsx` — the four KPI tiles + their grid + the totals calculation
- `client/src/components/statistics/StatisticsPopularActivitiesChart.jsx` — top-10 horizontal grouped bar chart
- `client/src/components/statistics/StatisticsParticipantsPerActivityChart.jsx` — vertical bar chart, all activities
- `client/src/components/statistics/StatisticsCancellationRateChart.jsx` — red horizontal bar chart

modified:
- `client/src/pages/StatisticsPage.jsx` 
- `client/src/pages/ProfilePage.jsx`

## how to test
since this is a pure refactor, the goal is to confirm nothing broke. all the same checks from PR-85 should still pass:

1. log in as ADMIN (`user1@example.com` / `user1pass`)
2. `/profile` → "📊 Open Statistics" button still on the hero card → click it
3. `/admin/statistics` → skeleton briefly → same KPI tiles + same three charts as before (visually identical)
4. wait ~40s → "Last updated" label should tick ("just now" → "30s ago" → "1 min ago"). this is the useNowTick hook working
5. refresh button → still shows "Refreshing…", timestamp resets, charts stay visible
6. export CSV → downloads same 6-column file as before
7. as LEADER / MEMBER → no stats button on `/profile`, `/admin/statistics` URL bounces to `/`
8. devtools console → no warnings about unused vars

## notes for review
- the JSDoc on `buildCsv` is mostly a warning to future-us: the columns + their order are part of an unwritten contract with whoever's consuming the CSV. comment makes that explicit so it doesn't get silently broken in a future PR
- naming: i went with the explicit `StatisticsXyzChart` prefix the ticket suggested, even though they're in a `statistics/` folder. the folder + prefix combo makes them very findable via filename search, and the prefix is self-documenting if a component ever gets imported elsewhere
- ActivityDetailPage still has inline `user.role === 'ADMIN'` checks in a couple of places. didn't touch them in this PR since the ticket is specifically about cleanup around StatisticsPage, but they could become `useIsAdmin()` calls in a small follow-up if we want. let me know if you'd prefer i fold that in here
- `chartTokens.js` only has color constants for now. if other chart-specific shared values come up later (default heights, margin presets, etc.) they should land here too