### PR TITLE
feat(activities): add leaderId filter and update leader activities client

### DIFF
--- a/client/src/services/LeaderActivitiesService.js
+++ b/client/src/services/LeaderActivitiesService.js
@@ -6,7 +6,7 @@ export async function fetchLeaderActivities(
   handleAuthExpired
 ) {
   const res = await fetch(
-    `${API_BASE_URL}/api/activities`,
+    `${API_BASE_URL}/api/activities?leaderId=${userId}`,
     {
       headers: {
         ...getAuthHeader(),
@@ -27,9 +27,5 @@ export async function fetchLeaderActivities(
     )
   }
 
-  return json.data.filter(activity =>
-    activity.leaders?.some(
-      leader => leader.id === userId
-    )
-  )
+  return json.data
 }

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -222,8 +222,9 @@ export const deleteActivity = asyncHandler(
 );
 
 export const getActivities = asyncHandler(
-  async (_req: Request, res: Response<ApiResponse<ActivityDto[]>>) => {
-    const data = await READ.allActivities();
+  async (req: Request, res: Response<ApiResponse<ActivityDto[]>>) => {
+    const leaderId = req.query.leaderId as string | undefined;
+    const data = await READ.allActivities(leaderId);
     res.status(200).json({
       status: "success",
       data,

--- a/server/src/controllers/activities.controller.ts
+++ b/server/src/controllers/activities.controller.ts
@@ -224,6 +224,11 @@ export const deleteActivity = asyncHandler(
 export const getActivities = asyncHandler(
   async (req: Request, res: Response<ApiResponse<ActivityDto[]>>) => {
     const leaderId = req.query.leaderId as string | undefined;
+
+    if (leaderId && !isUUID(leaderId)) {
+      throw ApiError.badRequest('Invalid leaderId format');
+    }
+
     const data = await READ.allActivities(leaderId);
     res.status(200).json({
       status: "success",

--- a/server/src/db/readQueries.ts
+++ b/server/src/db/readQueries.ts
@@ -175,10 +175,17 @@ export class READ {
         return activity ? formatActivity(activity) : null;
     }
     /**
-     * just returns all activityTemplates
+     * returns activityTemplates, optionally filtered by leaderId
      */
-    static async allActivities(): Promise<ActivityDto[]> {
+    static async allActivities(leaderId?: string): Promise<ActivityDto[]> {
+        const where = leaderId ? {
+            leaders: {
+                some: { profileId: leaderId }
+            }
+        } : {};
+
         let activities = await prisma.activityTemplate.findMany({
+            where,
             include: {
                 timeSlots: true,
                 leaders: {


### PR DESCRIPTION
## What it does

This PR adds support for filtering activities by `leaderId` in the backend and updates the leader activities client to use the new query parameter.

### Backend
- Extend `GET /api/activities` to accept an optional `leaderId` query param.
- Pass `leaderId` from the controller into `READ.allActivities(leaderId)`.
- Update `READ.allActivities` to optionally filter activities by leaders matching the given `leaderId`.

### Frontend
- Update `LeaderActivitiesService.js` to request `/api/activities?leaderId=${userId}` instead of the unfiltered endpoint.
- Remove client-side filtering of activities by leader and return the server-filtered list directly.
### Notes
- Keeps existing behavior when no `leaderId` is provided.
- Closes #111.