### PR TITLE
fix(seed): limit time slots per activity to reduce schedule clutter

### DIFF
--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -121,7 +121,7 @@ async function main() {
     const timeSlots = [];
 
     for (const activity of activities) {
-        const slotsPerActivity = Math.random() > 0.5 ? 2 : 1;
+        const slotsPerActivity = 1;
         // Shuffle weekdays so we never pick the same one twice for one activity
         const shuffledWeekdays = Object.values(Weekday).sort(() => Math.random() - 0.5);
 


### PR DESCRIPTION
## Description
This PR updates the database seed script to generate exactly 1 time slot per activity, rather than randomizing between 1 and 2 slots. 

The previous seed data was creating an overly busy schedule with multiple sessions per activity. By limiting the slots per activity during the database seeding phase, we get a much cleaner schedule right out of the box and avoid visual clutter.

## Deployment Notes
Once this is merged and deployed on Railway, the production database will need to be manually reset and re-seeded to reflect the new time slot limits. I'll do that by executing `npx prisma migrate reset --force` via the Railway dashboard's.