### PR TITLE
fix: generate schedule rows on activity creation + add week/month navigation

### DIFF
--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -41,6 +41,14 @@ const WEEKDAY_BY_INDEX = [
   'THURSDAY', 'FRIDAY', 'SATURDAY',
 ]
 
+function getMondayOfCurrentWeek() {
+  const d = new Date()
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
 export default function SchedulePage() {
 
   // ── View State ────────────────────────────────────────────
@@ -150,14 +158,7 @@ export default function SchedulePage() {
 
   // ── Current Date ──────────────────────────────────────────
   const today = new Date()
-  const [currentWeekStart, setCurrentWeekStart] = useState(() => {
-    const d = new Date(today)
-    const day = d.getDay()
-    const diff = d.getDate() - day + (day === 0 ? -6 : 1)
-    d.setDate(diff)
-    d.setHours(0, 0, 0, 0)
-    return d
-  })
+  const [currentWeekStart, setCurrentWeekStart] = useState(getMondayOfCurrentWeek)
   const [currentMonth, setCurrentMonth] = useState(() => new Date())
 
   // ── Fetch Current Schedule ───────────────────────────────
@@ -491,11 +492,12 @@ export default function SchedulePage() {
 
   function handleDatePick(e) {
     if (!e.target.value) return
-    const picked = new Date(e.target.value)
-    const day = picked.getUTCDay()
-    const diff = day === 0 ? -6 : 1 - day
-    picked.setUTCDate(picked.getUTCDate() + diff)
-    picked.setUTCHours(0, 0, 0, 0)
+    const [y, m, d] = e.target.value.split('-').map(Number)
+    const picked = new Date(y, m - 1, d)
+    const day = picked.getDay()
+    const diff = picked.getDate() - day + (day === 0 ? -6 : 1)
+    picked.setDate(diff)
+    picked.setHours(0, 0, 0, 0)
     setCurrentWeekStart(picked)
   }
 
@@ -710,14 +712,7 @@ export default function SchedulePage() {
         {view === 'weekly' ? (
           <>
             <Button variant="outline" size="sm" onClick={prevWeek}>← Prev</Button>
-            <Button variant="ghost" size="sm" onClick={() => {
-              const d = new Date()
-              const day = d.getDay()
-              const diff = d.getDate() - day + (day === 0 ? -6 : 1)
-              d.setDate(diff)
-              d.setHours(0, 0, 0, 0)
-              setCurrentWeekStart(d)
-            }}>Today</Button>
+            <Button variant="ghost" size="sm" onClick={() => setCurrentWeekStart(getMondayOfCurrentWeek())}>Today</Button>
             <Button variant="outline" size="sm" onClick={nextWeek}>Next →</Button>
             <input
               type="date"

--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -49,6 +49,54 @@ function getMondayOfCurrentWeek() {
   d.setHours(0, 0, 0, 0)
   return d
 }
+
+function formatScheduleData(singleSchedule) {
+  const startDate = new Date(singleSchedule.startAt)
+  const formattedDate = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-${String(startDate.getDate()).padStart(2, '0')}`
+
+  return {
+    id: singleSchedule.id,
+    activityId: singleSchedule.activityId,
+    title: singleSchedule.activity?.name || 'Activity',
+    sport: singleSchedule.activity?.name || 'Sport',
+    leader: singleSchedule.leaders
+      ?.map(leader => leader.profileName || 'Leader')
+      .join(', ') || 'Leader',
+    date: formattedDate,
+    time: startDate.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    }),
+    location: singleSchedule.activity?.location || 'Unknown',
+    maxCapacity: singleSchedule.activity?.maxCapacity ?? null,
+    participantCount: singleSchedule.participantCount ?? 0,
+    cancelled: singleSchedule.status === 'CANCELLED',
+    notes: singleSchedule.activity?.notes || '',
+  }
+}
+
+function getWeeksForMonth(date) {
+  const year = date.getFullYear()
+  const month = date.getMonth()
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+
+  // Find the Monday of the week containing firstDay
+  const monday = new Date(firstDay)
+  const day = monday.getDay()
+  const diff = monday.getDate() - day + (day === 0 ? -6 : 1)
+  monday.setDate(diff)
+  monday.setHours(0, 0, 0, 0)
+
+  const weeks = []
+  const current = new Date(monday)
+  while (current <= lastDay) {
+    weeks.push(new Date(current))
+    current.setDate(current.getDate() + 7)
+  }
+  return weeks
+}
+
 export default function SchedulePage() {
 
   // ── View State ────────────────────────────────────────────
@@ -163,114 +211,81 @@ export default function SchedulePage() {
 
   // ── Fetch Current Schedule ───────────────────────────────
   useEffect(() => {
+    let active = true
 
     async function fetchSchedule() {
 
       try {
-        // Single fetch — API_BASE_URL is '' in dev so the
-        // vite proxy handles it, and the deployed backend
-        // origin in production.
-        const dateParam = `${currentWeekStart.getFullYear()}-${String(currentWeekStart.getMonth() + 1).padStart(2, '0')}-${String(currentWeekStart.getDate()).padStart(2, '0')}`
-        const response = await fetch(
-          `${API_BASE_URL}/api/schedules?date=${dateParam}&entireWeek=true`
-        )
+        setLoading(true)
+        if (view === 'weekly') {
+          // Single fetch — API_BASE_URL is '' in dev so the
+          // vite proxy handles it, and the deployed backend
+          // origin in production.
+          const dateParam = `${currentWeekStart.getFullYear()}-${String(currentWeekStart.getMonth() + 1).padStart(2, '0')}-${String(currentWeekStart.getDate()).padStart(2, '0')}`
+          const response = await fetch(
+            `${API_BASE_URL}/api/schedules?date=${dateParam}&entireWeek=true`
+          )
 
-        const { data } = await response.json()
+          const { data } = await response.json()
 
-        console.log('Schedule API:', data)
+          console.log('Schedule API (weekly):', data)
 
-        // If backend returns schedule data
-        if (response.ok && Array.isArray(data)) {
+          // If backend returns schedule data
+          if (active && response.ok && Array.isArray(data)) {
+            const formattedActivities = data.map(formatScheduleData)
+            setActivities(formattedActivities)
+          }
+        } else {
+          // Monthly view: fetch all weeks intersecting with the month in parallel
+          const weeks = getWeeksForMonth(currentMonth)
+          const fetchPromises = weeks.map(async (week) => {
+            const dateParam = `${week.getFullYear()}-${String(week.getMonth() + 1).padStart(2, '0')}-${String(week.getDate()).padStart(2, '0')}`
+            const response = await fetch(
+              `${API_BASE_URL}/api/schedules?date=${dateParam}&entireWeek=true`
+            )
+            if (!response.ok) {
+              throw new Error(`Failed to fetch for week ${dateParam}`)
+            }
+            const { data } = await response.json()
+            return Array.isArray(data) ? data : []
+          })
 
-          // Transform backend format → frontend format
-          const formattedActivities = data.map(singleSchedule => ({
+          const weeklyDataArrays = await Promise.all(fetchPromises)
+          if (!active) return
 
-            id: singleSchedule.id,
+          const combinedData = weeklyDataArrays.flat()
+          console.log('Schedule API (monthly combined):', combinedData)
 
-            // activityId is the *template activity* id — the same
-            // ID that the favorites endpoint stores. We keep it
-            // so the "Favorites only" filter can match correctly.
-            activityId: singleSchedule.activityId,
-
-            title:
-              singleSchedule.activity?.name || 'Activity',
-
-            sport:
-              singleSchedule.activity?.name || 'Sport',
-
-            leader:
-              singleSchedule.leaders
-                ?.map(leader => leader.profileName || 'Leader')
-                .join(', ') || 'Leader',
-
-            date: (() => {
-
-              const startDate = new Date(singleSchedule.startAt)
-
-              return `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')
-                }-${String(startDate.getDate()).padStart(2, '0')
-                }`
-
-            })(),
-
-            time: new Date(singleSchedule.startAt)
-              .toLocaleTimeString([], {
-                hour: '2-digit',
-                minute: '2-digit',
-              }),
-
-            location:
-              singleSchedule.activity?.location || 'Unknown',
-
-            // Max capacity from the activity template + the number
-            // of currently registered participants. We compute
-            // "spots left" at render time as the difference between
-            // these two. Both fields drive the disable-when-full
-            // logic on the Attend button.
-            //
-            // NOTE: the /api/schedules/current endpoint doesn't
-            // include participantCount yet, so we default it to 0
-            // on initial load. The count updates correctly the
-            // moment the user clicks Attend / Leave (the response
-            // from /participate returns the authoritative count).
-            // Backend ticket needed to include participantCount in
-            // the schedule list response for accurate first paint.
-            maxCapacity:
-              singleSchedule.activity?.maxCapacity ?? null,
-            participantCount:
-              singleSchedule.participantCount ?? 0,
-
-            cancelled:
-              singleSchedule.status === 'CANCELLED',
-
-            notes:
-              singleSchedule.activity?.notes || '',
-
-          }))
-
+          const formattedActivities = combinedData.map(formatScheduleData)
           setActivities(formattedActivities)
         }
 
       } catch (error) {
-
-        // Public endpoint, but the network could still fail or the
-        // backend could 500. Previously this was silent + the page
-        // just rendered empty — now we tell the user with a toast
-        // so they know to retry instead of staring at mock data.
-        console.error('Failed to fetch schedule:', error)
-        showToast(
-          'Couldn\'t load the schedule. Please try again.',
-          'error',
-        )
+        if (active) {
+          // Public endpoint, but the network could still fail or the
+          // backend could 500. Previously this was silent + the page
+          // just rendered empty — now we tell the user with a toast
+          // so they know to retry instead of staring at mock data.
+          console.error('Failed to fetch schedule:', error)
+          showToast(
+            'Couldn\'t load the schedule. Please try again.',
+            'error',
+          )
+        }
       } finally {
-        setLoading(false)
+        if (active) {
+          setLoading(false)
+        }
       }
     }
 
     fetchSchedule()
 
+    return () => {
+      active = false
+    }
 
-  }, [currentWeekStart])
+  }, [view, currentWeekStart, currentMonth])
 
   // ── Fetch Favorites (logged-in users only) ───────────────
   // Mirrors the pattern already used in ActivitiesPage so the

--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -150,8 +150,15 @@ export default function SchedulePage() {
 
   // ── Current Date ──────────────────────────────────────────
   const today = new Date()
-  // Test for JUNE
-  //const today = new Date('2026-06-15')
+  const [currentWeekStart, setCurrentWeekStart] = useState(() => {
+    const d = new Date(today)
+    const day = d.getDay()
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+    d.setDate(diff)
+    d.setHours(0, 0, 0, 0)
+    return d
+  })
+  const [currentMonth, setCurrentMonth] = useState(() => new Date())
 
   // ── Fetch Current Schedule ───────────────────────────────
   useEffect(() => {
@@ -162,8 +169,9 @@ export default function SchedulePage() {
         // Single fetch — API_BASE_URL is '' in dev so the
         // vite proxy handles it, and the deployed backend
         // origin in production.
+        const dateParam = `${currentWeekStart.getFullYear()}-${String(currentWeekStart.getMonth() + 1).padStart(2, '0')}-${String(currentWeekStart.getDate()).padStart(2, '0')}`
         const response = await fetch(
-          `${API_BASE_URL}/api/schedules/current`
+          `${API_BASE_URL}/api/schedules?date=${dateParam}&entireWeek=true`
         )
 
         const { data } = await response.json()
@@ -260,10 +268,8 @@ export default function SchedulePage() {
 
     fetchSchedule()
 
-    // showToast is stable (useCallback) — keeping the deps array
-    // empty preserves the original "fetch once on mount" behaviour.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+
+  }, [currentWeekStart])
 
   // ── Fetch Favorites (logged-in users only) ───────────────
   // Mirrors the pattern already used in ActivitiesPage so the
@@ -416,29 +422,16 @@ export default function SchedulePage() {
     const result = []
 
     if (view === 'weekly') {
-
-      // Get Monday of current week
-      const current = new Date(today)
-
-      const day = current.getDay()
-      const diff = current.getDate() - day + (day === 0 ? -6 : 1)
-
-      current.setDate(diff)
-
       for (let i = 0; i < 7; i++) {
-        const date = new Date(current)
-        date.setDate(current.getDate() + i)
+        const date = new Date(currentWeekStart)
+        date.setDate(currentWeekStart.getDate() + i)
         result.push(date)
       }
-
     } else {
-
       // Monthly view
-      const year = today.getFullYear()
-      const month = today.getMonth()
-
+      const year = currentMonth.getFullYear()
+      const month = currentMonth.getMonth()
       const daysInMonth = new Date(year, month + 1, 0).getDate()
-
       for (let i = 1; i <= daysInMonth; i++) {
         result.push(new Date(year, month, i))
       }
@@ -446,7 +439,7 @@ export default function SchedulePage() {
 
     return result
 
-  }, [view])
+  }, [view, currentWeekStart, currentMonth])
 
   // ── Helper: Activities For A Specific Day ────────────────
   function getActivitiesForDay(date) {
@@ -479,6 +472,40 @@ export default function SchedulePage() {
     setFilterFavoritesOnly(false)
   }
 
+
+  function prevWeek() {
+    setCurrentWeekStart(d => {
+      const n = new Date(d)
+      n.setDate(d.getDate() - 7)
+      return n
+    })
+  }
+
+  function nextWeek() {
+    setCurrentWeekStart(d => {
+      const n = new Date(d)
+      n.setDate(d.getDate() + 7)
+      return n
+    })
+  }
+
+  function handleDatePick(e) {
+    if (!e.target.value) return
+    const picked = new Date(e.target.value)
+    const day = picked.getUTCDay()
+    const diff = day === 0 ? -6 : 1 - day
+    picked.setUTCDate(picked.getUTCDate() + diff)
+    picked.setUTCHours(0, 0, 0, 0)
+    setCurrentWeekStart(picked)
+  }
+
+  function prevMonth() {
+    setCurrentMonth(d => new Date(d.getFullYear(), d.getMonth() - 1, 1))
+  }
+
+  function nextMonth() {
+    setCurrentMonth(d => new Date(d.getFullYear(), d.getMonth() + 1, 1))
+  }
   // ── Toggle Attendance ────────────────────────────────────
   // Wires the Attend / Leave button on each card to the backend.
   // Pattern mirrors ActivitiesPage.handleToggleFavorite:
@@ -678,20 +705,46 @@ export default function SchedulePage() {
           empty. Please try again in a moment.
         </p>
       )}
-
-      {/* Month header, placed above the calendar */}
-      <h2
-        style={{
-          fontSize: '2rem',
-          fontWeight: 800,
-          letterSpacing: '4px',
-          marginBottom: '24px',
-        }}
-      >
-        {today.toLocaleDateString('en-US', {
-          month: 'long',
-        }).toUpperCase()}
-      </h2>
+      {/* Month header + navigation */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', flexWrap: 'wrap' }}>
+        {view === 'weekly' ? (
+          <>
+            <Button variant="outline" size="sm" onClick={prevWeek}>← Prev</Button>
+            <Button variant="ghost" size="sm" onClick={() => {
+              const d = new Date()
+              const day = d.getDay()
+              const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+              d.setDate(diff)
+              d.setHours(0, 0, 0, 0)
+              setCurrentWeekStart(d)
+            }}>Today</Button>
+            <Button variant="outline" size="sm" onClick={nextWeek}>Next →</Button>
+            <input
+              type="date"
+              onChange={handleDatePick}
+              style={{
+                padding: '6px 10px',
+                border: '1.5px solid var(--color-border)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: 'var(--text-sm)',
+                fontFamily: 'var(--font-body)',
+                background: 'var(--color-surface-raised)',
+                color: 'var(--color-text)',
+                cursor: 'pointer',
+              }}
+            />
+          </>
+        ) : (
+          <>
+            <Button variant="outline" size="sm" onClick={prevMonth}>← Prev</Button>
+            <Button variant="ghost" size="sm" onClick={() => setCurrentMonth(new Date())}>Today</Button>
+            <Button variant="outline" size="sm" onClick={nextMonth}>Next →</Button>
+          </>
+        )}
+        <h2 style={{ fontSize: '2rem', fontWeight: 800, letterSpacing: '4px', margin: 0 }}>
+          {(view === 'weekly' ? currentWeekStart : currentMonth).toLocaleDateString('en-US', { month: 'long' }).toUpperCase()}
+        </h2>
+      </div>
 
       {/* Calendar Grid */}
       <div

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -77,12 +77,16 @@ export class CREATE {
 
             // Generate Schedule rows for current + next 2 weeks
             const today = new Date();
+            const todayDow = today.getUTCDay();
+            const monday = new Date(today);
+            monday.setUTCDate(today.getUTCDate() - ((todayDow + 6) % 7));
+
             const scheduleData = [];
 
             for (const slot of created.timeSlots) {
                 for (let week = 0; week < 3; week++) {
-                    const base = new Date(today);
-                    base.setUTCDate(today.getUTCDate() + week * 7);
+                    const base = new Date(monday);
+                    base.setUTCDate(monday.getUTCDate() + week * 7);
 
                     const date = nextDateForWeekday(base, slot.weekday);
 
@@ -109,8 +113,7 @@ export class CREATE {
                 }
             }
 
-            await tx.schedule.createMany({ data: scheduleData });
-
+            await tx.schedule.createMany({ data: scheduleData, skipDuplicates: true });
             return created;
         });
 

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -1,21 +1,11 @@
 import { Activity, FavoriteCreateDelete, ActivityDto, ScheduleDto } from "../types/index.js";
 import { prisma, ActivityStatus } from "./prisma.js";
 import { ApiError } from "../utils/ApiError.js";
-import {formatActivity, formatSchedule} from "./utils.js";
-/*
-CREATE Queries
-    create new profile
-        adding favorites → use connect clause, cause the activities already exist
-    create new activity
-    add new time slot to an activity
-    perhaps a query for attending activity, CREATE query for Participations (e.g., linking a profile_id to a time_slot_id). wdyt?
-    add a new week to the schedule
- */
-
+import { formatActivity, formatSchedule } from "./utils.js";
+import { nextDateForWeekday } from "../utils/weekCalculator.js";
 
 export class CREATE {
 
-    // adding favorites
     static async newFavorite(ids: FavoriteCreateDelete): Promise<ActivityDto> {
         const { activity } = await prisma.favorite.create({
             data: {
@@ -44,45 +34,86 @@ export class CREATE {
     }
 
     static async newActivity(newAct: Activity): Promise<ActivityDto> {
-        const activity = await prisma.activityTemplate.create({
-            data: {
-                name: newAct.name,
-                location: newAct.location,
-                description: newAct.description,
-                notes: newAct.notes,
-                defaultStatus: newAct.defaultStatus,
-                maxCapacity: newAct.maxCapacity,
-                leaders: {
-                    createMany: {
-                        data: newAct.leaders.map((profileId) => ({
-                            profileId
-                        }))
-                    }
+        const activity = await prisma.$transaction(async (tx) => {
+
+            // Create the activity template with leaders and time slots
+            const created = await tx.activityTemplate.create({
+                data: {
+                    name: newAct.name,
+                    location: newAct.location,
+                    description: newAct.description,
+                    notes: newAct.notes,
+                    defaultStatus: newAct.defaultStatus,
+                    maxCapacity: newAct.maxCapacity,
+                    leaders: {
+                        createMany: {
+                            data: newAct.leaders.map((profileId) => ({ profileId }))
+                        }
+                    },
+                    timeSlots: {
+                        createMany: {
+                            data: newAct.timeSlots.map(el => ({
+                                weekday: el.weekday,
+                                startTime: new Date(`1970-01-01T${el.startAt}Z`),
+                                endTime: new Date(`1970-01-01T${el.endAt}Z`)
+                            }))
+                        }
+                    },
                 },
-                timeSlots: {
-                    createMany: {
-                        data: newAct.timeSlots.map(el => ({
-                            weekday: el.weekday,
-                            startTime: new Date(`1970-01-01T${el.startAt}Z`),
-                            endTime: new Date(`1970-01-01T${el.endAt}Z`)
-                        }))
-                    }
-                },
-            },
-            include: {
-                timeSlots: true,
-                leaders: {
-                    select: {
-                        profile: {
-                            select: {
-                                id: true,
-                                profileName: true
+                include: {
+                    timeSlots: true,
+                    leaders: {
+                        select: {
+                            profile: {
+                                select: {
+                                    id: true,
+                                    profileName: true
+                                }
                             }
                         }
                     }
                 }
+            });
+
+            // Generate Schedule rows for current + next 2 weeks
+            const today = new Date();
+            const scheduleData = [];
+
+            for (const slot of created.timeSlots) {
+                for (let week = 0; week < 3; week++) {
+                    const base = new Date(today);
+                    base.setUTCDate(today.getUTCDate() + week * 7);
+
+                    const date = nextDateForWeekday(base, slot.weekday);
+
+                    const start = new Date(date);
+                    start.setUTCHours(
+                        slot.startTime.getUTCHours(),
+                        slot.startTime.getUTCMinutes(),
+                        0, 0
+                    );
+
+                    const end = new Date(date);
+                    end.setUTCHours(
+                        slot.endTime.getUTCHours(),
+                        slot.endTime.getUTCMinutes(),
+                        0, 0
+                    );
+
+                    scheduleData.push({
+                        activityId: created.id,
+                        startAt: start,
+                        endAt: end,
+                        status: created.defaultStatus,
+                    });
+                }
             }
+
+            await tx.schedule.createMany({ data: scheduleData });
+
+            return created;
         });
+
         return formatActivity(activity);
     }
 
@@ -138,7 +169,6 @@ export class CREATE {
 
     static async registerParticipation(profileId: string, scheduleId: string, activityId: string): Promise<number> {
         return await prisma.$transaction(async (tx) => {
-            // Check schedule exists and belongs to this activity
             const schedule = await tx.schedule.findUnique({
                 where: { id: scheduleId },
                 include: { activity: true }
@@ -146,7 +176,6 @@ export class CREATE {
             if (!schedule) throw ApiError.notFound('Schedule not found')
             if (schedule.activityId !== activityId) throw ApiError.badRequest('Schedule does not belong to this activity')
 
-            // Check capacity
             if (schedule.activity.maxCapacity !== null) {
                 const count = await tx.participationLog.count({ where: { scheduleId } })
                 if (count >= schedule.activity.maxCapacity) {
@@ -154,7 +183,6 @@ export class CREATE {
                 }
             }
 
-            // Check not already registered
             const existing = await tx.participationLog.findUnique({
                 where: { profileId_scheduleId: { profileId, scheduleId } }
             })
@@ -166,6 +194,5 @@ export class CREATE {
 
             return await tx.participationLog.count({ where: { scheduleId } })
         })
-
     }
 }

--- a/server/src/utils/weekCalculator.ts
+++ b/server/src/utils/weekCalculator.ts
@@ -42,16 +42,18 @@ export function lastWeek(date: Date, numberOfWeeks: number): Date {
 
 
 /**
- * Given a base date and a Weekday enum string (e.g. 'MONDAY'),
- * returns the date of that weekday in the same week as the base date.
- * If the base date IS that weekday, returns the same day.
+ * Returns the date of the given weekday in the same ISO week as `from`.
+ * If `from` is already on that weekday, returns the same day.
  */
 export function nextDateForWeekday(from: Date, weekday: string): Date {
     const days = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
     const target = days.indexOf(weekday);
-    const current = from.getUTCDay();
-    const diff = (target - current + 7) % 7;
-    const result = new Date(from);
-    result.setUTCDate(from.getUTCDate() + diff);
-    return result;
+    const dow = from.getUTCDay();
+    // Monday of from's ISO week
+    const weekStart = new Date(from);
+    weekStart.setUTCDate(from.getUTCDate() - ((dow + 6) % 7));
+    // Add ISO weekday offset (Mon=0 ... Sun=6)
+    const isoTarget = (target + 6) % 7;
+    weekStart.setUTCDate(weekStart.getUTCDate() + isoTarget);
+    return weekStart;
 }

--- a/server/src/utils/weekCalculator.ts
+++ b/server/src/utils/weekCalculator.ts
@@ -22,7 +22,7 @@ export function startAndEndOfWeek(nowDate: Date) {
 }
 
 // Returns the date N weeks in the future.
- 
+
 export function nextWeek(date: Date, numberOfWeeks: number): Date {
     if (numberOfWeeks === 0) return date;
     const result = new Date(date);
@@ -37,5 +37,21 @@ export function lastWeek(date: Date, numberOfWeeks: number): Date {
     if (numberOfWeeks === 0) return date;
     const result = new Date(date);
     result.setUTCDate(date.getUTCDate() - Math.abs(Math.trunc(numberOfWeeks)) * 7);
+    return result;
+}
+
+
+/**
+ * Given a base date and a Weekday enum string (e.g. 'MONDAY'),
+ * returns the date of that weekday in the same week as the base date.
+ * If the base date IS that weekday, returns the same day.
+ */
+export function nextDateForWeekday(from: Date, weekday: string): Date {
+    const days = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+    const target = days.indexOf(weekday);
+    const current = from.getUTCDay();
+    const diff = (target - current + 7) % 7;
+    const result = new Date(from);
+    result.setUTCDate(from.getUTCDate() + diff);
     return result;
 }


### PR DESCRIPTION
## What this PR does

### Bug fix - new activities not appearing in schedule
When an admin/leader created a new activity, it would never appear in 
the schedule. The root cause was that `CREATE.newActivity()` only 
created the `ActivityTemplate` and `TimeSlot` rows but never inserted 
any `Schedule` rows. Schedule rows were previously only generated by 
the seeder.

Fix: `newActivity` now generates `Schedule` rows for the current + 
next 2 weeks inside the same `$transaction` when a new activity is 
created. If the schedule generation fails, the whole activity creation 
rolls back.

### Feature - week/month navigation on schedule page
The schedule page previously had no navigation - users were stuck on 
the current week/month with no way to look ahead or go back.

Added:
- ← Prev / Next → buttons for both weekly and monthly views
- Today button to jump back to current week/month
- Date picker to jump to any specific date (weekly view)
- Month label updates dynamically when navigating

## Files changed
- `server/src/utils/weekCalculator.ts` - extracted `nextDateForWeekday` utility
- `server/src/db/createQueries.ts` - generate Schedule rows on activity creation
- `client/src/pages/SchedulePage.jsx` - week/month navigation UI + fetch refetch on navigation

## Known limitation
Activities only appear in the schedule for the weeks that have been 
generated (~2-3 weeks ahead). Weeks further in the future will show 
empty until a cron job is implemented to generate schedule rows 
on a rolling weekly basis. That will be handled in a follow-up PR.

## Testing
- Create a new activity as admin/leader
- Navigate to the correct week - activity should appear immediately
- Prev/Next buttons navigate correctly
- Date picker jumps to the right week
- Monthly prev/next navigation works
- Today button returns to current week/month

## Closes
Closes #119