### PR TITLE
fix(auth): handle expired and malformed JWTs with 401 Unauthorized (fixes #106)

### DIFF
--- a/server/src/__tests__/auth.test.ts
+++ b/server/src/__tests__/auth.test.ts
@@ -176,15 +176,25 @@ describe('GET /api/auth/me', () => {
     expect(res.body.error).toBeDefined();
   });
 
-  it('returns 500 when token is malformed (unhandled JWT error)', async () => {
-    // NOTE: verifyToken throws JsonWebTokenError which is not an ApiError,
-    // so the global error handler returns 500. This is existing behaviour —
-    // a future improvement could catch it in authMiddleware and return 401.
+  it('returns 401 when token is malformed (unhandled JWT error)', async () => {
     const res = await request(app)
       .get('/api/auth/me')
       .set('Authorization', 'Bearer invalid.token.here');
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(401);
     expect(res.body.error).toBeDefined();
+  });
+
+  it('returns 401 when token is expired', async () => {
+    const jwt = require('jsonwebtoken');
+    const expiredToken = jwt.sign({ id: testUUID(), role: 'MEMBER' }, process.env.JWT_SECRET || 'secret', { expiresIn: '-1h' });
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${expiredToken}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error).toMatch(/expired/i);
   });
 });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -29,7 +29,15 @@ export const authMiddleware = asyncHandler(async (req, _res, next) => {
   }
 
   const token = header.split(' ')[1]!;
-  const decoded = verifyToken(token); // throws on invalid / expired
+  let decoded;
+  try {
+    decoded = verifyToken(token); // throws on invalid / expired
+  } catch (error: any) {
+    if (error.name === 'TokenExpiredError') {
+      throw ApiError.unauthorized('Token expired');
+    }
+    throw ApiError.unauthorized('Invalid token');
+  }
 
   const currentUser = await prisma.profile.findUnique({
     where: { id: decoded.id },


### PR DESCRIPTION
## Root Cause
When an incoming request included an expired JSON Web Token (JWT) or an invalid token, the `verifyToken` utility in `authMiddleware` would throw a `TokenExpiredError (or JsonWebTokenError)`. Since these exceptions were not explicitly caught in the middleware, they were forwarded to the global error handler (errorHandler). Because they weren't instances of `ApiError`, the global error handler fell back to returning a generic 500 Internal Server Error.

## The Fix
Wrapped the `verifyToken(token)` call in `authMiddleware` with a `try/catch` block. Explicitly caught errors thrown by the `jsonwebtoken` library. If a `TokenExpiredError` is thrown, the middleware now returns a strict `401 Unauthorized` response with the message "Token expired". For any other token verification failure, it returns "Invalid token". Added tests to assert that `GET /api/auth/me` with an expired token or malformed token explicitly responds with 401 Unauthorized as expected.

## How to Test
Automated Tests: Run the backend tests and ensure the updated authentication test suite passes:
```
bash
cd server
npx vitest run src/__tests__/auth.test.ts
```
## Manual Testing:
Log into the application and extract your token.
Wait for the token to expire (or forcefully mint an expired one locally).
Use a tool like Postman or curl to hit an authenticated endpoint (e.g. `GET /api/auth/me`) using the expired token.
Verify the response status code is 401 rather than 500, and that the JSON body contains `{ "error": "Token expired", "statusCode": 401 }`.