### PR TITLE
Time frame checks for attending an activity, FE & BE

### DIFF
--- a/client/src/pages/SchedulePage.jsx
+++ b/client/src/pages/SchedulePage.jsx
@@ -871,6 +871,14 @@ export default function SchedulePage() {
                     const isFull = hasCapacityData
                       && activity.participantCount >= activity.maxCapacity
 
+                    const time = activity.time.split(' ')[0].split(':')
+                    //default ending time is two hours, this is the magic number here
+                    time[0] = Number(time[0]) + 2;
+                    //needed to properly convert the updated endAt to a string that is usable in date creation
+                    if(time[0]<10) time[0] = `0${time[0]}`
+                    const str = new Date(`${activity.date}T${time[0]}:${time[1]}`);
+                    const isInThePast = str.getTime() < today.getTime();
+
                     return (
 
                       <div
@@ -969,17 +977,21 @@ export default function SchedulePage() {
                         {!activity.cancelled && (
                           <Button
                             size="sm"
-                            variant={isAttending ? 'ghost' : 'primary'}
+                            variant={isAttending || isInThePast ? 'ghost' : 'primary'}
                             // Disable when the schedule is full AND the
                             // user isn't already attending. Attendees
                             // can still leave a full session.
-                            disabled={(!isAttending && isFull) || attendanceLoading[activity.id]}
+                            disabled={(!isAttending && isFull) || isInThePast || attendanceLoading[activity.id]}
                             style={{ marginTop: '8px' }}
                             onClick={() => handleToggleAttendance(activity)}
                           >
-                            {isAttending
-                              ? 'Leave'
-                              : (isFull ? 'Full' : 'Attend')}
+                            {
+                               isInThePast ? 'Past' : (
+                                   isAttending
+                                       ? 'Leave'
+                                       : (isFull ? 'Full' : 'Attend')
+                               )
+                            }
                           </Button>
                         )}
 

--- a/server/src/db/createQueries.ts
+++ b/server/src/db/createQueries.ts
@@ -179,6 +179,17 @@ export class CREATE {
             if (!schedule) throw ApiError.notFound('Schedule not found')
             if (schedule.activityId !== activityId) throw ApiError.badRequest('Schedule does not belong to this activity')
 
+            const now = Date.now()
+            if ( schedule.startAt.getTime() < now   ) throw ApiError.badRequest(`The event is in the Past`)
+            if( schedule.endAt && schedule.endAt.getTime() < now){
+                throw ApiError.badRequest(`The event is in the Past`)
+            }
+            if ( !schedule.endAt ) {
+                //default end time is two hours after the start time
+                const defaultEnd = new Date(schedule.startAt).setUTCHours(schedule.startAt.getUTCHours() + 2 )
+                if(defaultEnd < now) throw ApiError.badRequest(`The event is in the Past`)
+            }
+
             if (schedule.activity.maxCapacity !== null) {
                 const count = await tx.participationLog.count({ where: { scheduleId } })
                 if (count >= schedule.activity.maxCapacity) {


### PR DESCRIPTION
Closes #127
Files touched:
- SchedulePage.jsx
- createQueries.ts

<img width="320" height="776" alt="Screenshot from 2026-06-16 17-32-42" src="https://github.com/user-attachments/assets/cf534440-b6b6-4079-823a-7c2bed374245" />



# SchedulePage.jsx
Implemented:
- a boolean `isInThePast` --> true if the end time of the activity is smaller than the current date and time (uses default two hours from beginning of scheduled activity)
```javascript
const time = activity.time.split(' ')[0].split(':')
                    //default ending time is two hours, this is the magic number here
                    time[0] = Number(time[0]) + 2;
                    //needed to properly convert the updated endAt to a string that is usable in date creation
                    if(time[0]<10) time[0] = `0${time[0]}`
                    const str = new Date(`${activity.date}T${time[0]}:${time[1]}`);
                    const isInThePast = str.getTime() < today.getTime();
```

- conditional button rendering:
```javascript
<Button
    size="sm"
    variant={isAttending || isInThePast ? 'ghost' : 'primary'}
    // Disable when the schedule is full AND the
    // user isn't already attending. Attendees
    // can still leave a full session.
    disabled={(!isAttending && isFull) || isInThePast || attendanceLoading[activity.id]}
    style={{ marginTop: '8px' }}
    onClick={() => handleToggleAttendance(activity)}
  >
    {
       isInThePast ? 'Past' : (
           isAttending
               ? 'Leave'
               : (isFull ? 'Full' : 'Attend')
       )
    }
</Button>
```

# createQueries.ts
Implemented additional condition to check if the current time is in the time frame of the activity
```typescript
const now = Date.now()
if ( schedule.startAt.getTime() < now   ) throw ApiError.badRequest(`The event is in the Past`)
if( schedule.endAt && schedule.endAt.getTime() < now){
    throw ApiError.badRequest(`The event is in the Past`)
}
if ( !schedule.endAt ) {
    //default end time is two hours after the start time
    const defaultEnd = new Date(schedule.startAt).setUTCHours(schedule.startAt.getUTCHours() + 2 )
    if(defaultEnd < now) throw ApiError.badRequest(`The event is in the Past`)
}
```